### PR TITLE
Feature/Update zync controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else ifeq (${UNAME}, Darwin)
   INPLACE_SED=sed -i ""
 endif
 
-TAG ?= v0.3.0
+TAG ?= v0.3.1
 REGISTRY ?= quay.io
 ORG ?= 3scale
 PROJECT ?= 3scale-saas-operator

--- a/deploy/crds/saas.3scale.net_v1alpha1_zync_cr.yaml
+++ b/deploy/crds/saas.3scale.net_v1alpha1_zync_cr.yaml
@@ -10,7 +10,5 @@ spec:
     resources:
       limits:
         cpu: "1"
-    env:
-      dbWaitSleepSeconds: 1
   que:
     replicas: 1

--- a/deploy/crds/saas.3scale.net_zyncs_crd.yaml
+++ b/deploy/crds/saas.3scale.net_zyncs_crd.yaml
@@ -64,9 +64,6 @@ spec:
                 env:
                   type: object
                   properties:
-                    railsLogsToStdout:
-                      type: boolean
-                      description: Rails log to std output toggle for zync
                     railsEnv:
                       type: string
                       description: Rails environment for zync
@@ -134,9 +131,6 @@ spec:
                 env:
                   type: object
                   properties:
-                    railsLogsToStdout:
-                      type: boolean
-                      description: Rails log to std output toggle for zync
                     railsEnv:
                       type: string
                       description: Rails environment for zync

--- a/deploy/crds/saas.3scale.net_zyncs_crd.yaml
+++ b/deploy/crds/saas.3scale.net_zyncs_crd.yaml
@@ -64,9 +64,6 @@ spec:
                 env:
                   type: object
                   properties:
-                    dbWaitSleepSeconds:
-                      type: integer
-                      description: Sleep delay while waiting for the zync database
                     railsLogsToStdout:
                       type: boolean
                       description: Rails log to std output toggle for zync

--- a/docs/zync-crd-reference.md
+++ b/docs/zync-crd-reference.md
@@ -39,7 +39,7 @@ spec:
   zync:
     replicas: 2
     env:
-      railsEnv: dev
+      railsEnv: development
       railsLogsToStdout: true
     resources:
       requests:
@@ -63,7 +63,7 @@ spec:
   que:
     replicas: 2
     env:
-      railsEnv: dev
+      railsEnv: development
       railsLogsToStdout: true
     resources:
       requests:
@@ -98,7 +98,7 @@ spec:
 |                `image.tag`                | `string` |      No      |       `nightly`       |                       Image tag for zync                       |
 |          `image.pullSecretName`           | `string` |      No      |           -           |    Pull secret for private container repository if required    |
 |            `secret.vaultPath`             | `string` |     Yes      |           -           |                Vault path with the zync secrets                |
-|            `zync.env.railsEnv`            | `string` |      No      |         `dev`         |                   Rails environment for zync                   |
+|            `zync.env.railsEnv`            | `string` |      No      |     `development`     |    Rails environment for zync (test/development/production)    |
 |       `zync.env.railsLogsToStdout`        | `string` |      No      |        `false`        |            Rails log to std output toggle for zync             |
 |              `zync.replicas`              |  `int`   |      No      |          `2`          |                  Number of replicas for zync                   |
 |       `zync.resources.requests.cpu`       | `string` |      No      |        `250m`         |                 Override CPU requests for zync                 |
@@ -116,7 +116,7 @@ spec:
 |  `zync.readinessProbe.successThreshold`   |  `int`   |      No      |          `1`          |         Override readiness success threshold for zync          |
 |  `zync.readinessProbe.failureThreshold`   |  `int`   |      No      |          `3`          |         Override readiness failure threshold for zync          |
 |              `que.replicas`               |  `int`   |      No      |          `2`          |                Number of replicas for zync-que                 |
-|            `que.env.railsEnv`             | `string` |      No      |         `dev`         |                 Rails environment for zync-que                 |
+|            `que.env.railsEnv`             | `string` |      No      |     `development`     |  Rails environment for zync-que (test/development/production)  |
 |        `que.env.railsLogsToStdout`        | `string` |      No      |        `false`        |           Rail log to std output toggle for zync-que           |
 |       `que.resources.requests.cpu`        | `string` |      No      |        `250m`         |               Override CPU requests for zync-que               |
 |      `que.resources.requests.memory`      | `string` |      No      |        `250Mi`        |             Override Memory requests for zync-que              |

--- a/docs/zync-crd-reference.md
+++ b/docs/zync-crd-reference.md
@@ -14,8 +14,6 @@ spec:
     vaultPath: secret/data/openshift/dev-example-4-3/3scale-zync
   zync:
     replicas: 1
-    env:
-      dbWaitSleepSeconds: 60
     resources:
       limits:
         cpu: "1"
@@ -41,7 +39,6 @@ spec:
   zync:
     replicas: 2
     env:
-      dbWaitSleepSeconds: 10
       railsEnv: dev
       railsLogsToStdout: true
     resources:
@@ -101,7 +98,6 @@ spec:
 |                `image.tag`                | `string` |      No      |       `nightly`       |                       Image tag for zync                       |
 |          `image.pullSecretName`           | `string` |      No      |           -           |    Pull secret for private container repository if required    |
 |            `secret.vaultPath`             | `string` |     Yes      |           -           |                Vault path with the zync secrets                |
-|      `zync.env.dbWaitSleepSeconds `       |  `int`   |      No      |         `30`          |        Sleep delay while waiting for the zync database         |
 |            `zync.env.railsEnv`            | `string` |      No      |         `dev`         |                   Rails environment for zync                   |
 |       `zync.env.railsLogsToStdout`        | `string` |      No      |        `false`        |            Rails log to std output toggle for zync             |
 |              `zync.replicas`              |  `int`   |      No      |          `2`          |                  Number of replicas for zync                   |

--- a/docs/zync-crd-reference.md
+++ b/docs/zync-crd-reference.md
@@ -40,7 +40,6 @@ spec:
     replicas: 2
     env:
       railsEnv: development
-      railsLogsToStdout: true
     resources:
       requests:
         cpu: "300m"
@@ -64,7 +63,6 @@ spec:
     replicas: 2
     env:
       railsEnv: development
-      railsLogsToStdout: true
     resources:
       requests:
         cpu: "250m"
@@ -99,7 +97,6 @@ spec:
 |          `image.pullSecretName`           | `string` |      No      |           -           |    Pull secret for private container repository if required    |
 |            `secret.vaultPath`             | `string` |     Yes      |           -           |                Vault path with the zync secrets                |
 |            `zync.env.railsEnv`            | `string` |      No      |     `development`     |    Rails environment for zync (test/development/production)    |
-|       `zync.env.railsLogsToStdout`        | `string` |      No      |        `false`        |            Rails log to std output toggle for zync             |
 |              `zync.replicas`              |  `int`   |      No      |          `2`          |                  Number of replicas for zync                   |
 |       `zync.resources.requests.cpu`       | `string` |      No      |        `250m`         |                 Override CPU requests for zync                 |
 |     `zync.resources.requests.memory`      | `string` |      No      |        `250Mi`        |               Override Memory requests for zync                |
@@ -117,7 +114,6 @@ spec:
 |  `zync.readinessProbe.failureThreshold`   |  `int`   |      No      |          `3`          |         Override readiness failure threshold for zync          |
 |              `que.replicas`               |  `int`   |      No      |          `2`          |                Number of replicas for zync-que                 |
 |            `que.env.railsEnv`             | `string` |      No      |     `development`     |  Rails environment for zync-que (test/development/production)  |
-|        `que.env.railsLogsToStdout`        | `string` |      No      |        `false`        |           Rail log to std output toggle for zync-que           |
 |       `que.resources.requests.cpu`        | `string` |      No      |        `250m`         |               Override CPU requests for zync-que               |
 |      `que.resources.requests.memory`      | `string` |      No      |        `250Mi`        |             Override Memory requests for zync-que              |
 |        `que.resources.limits.cpu`         | `string` |      No      |        `750m`         |                Override CPU limits for zync-que                |

--- a/roles/zync/defaults/main.yml
+++ b/roles/zync/defaults/main.yml
@@ -4,7 +4,7 @@ image_name: "quay.io/3scale/zync"
 image_tag: "nightly"
 
 ## Zync Deployment
-zync_replicas: 3
+zync_replicas: 2
 ### Zync Deployment Env
 zync_env_rails_log_to_stdout: false
 zync_env_rails_env: dev
@@ -27,7 +27,7 @@ zync_readiness_probe_success_threshold: 1
 zync_readiness_probe_failure_threshold: 3
 
 ## Zync-Que Deployment
-que_replicas: 3
+que_replicas: 2
 ### Zync Deployment Env
 que_env_rails_log_to_stdout: false
 que_env_rails_env: dev

--- a/roles/zync/defaults/main.yml
+++ b/roles/zync/defaults/main.yml
@@ -6,7 +6,6 @@ image_tag: "nightly"
 ## Zync Deployment
 zync_replicas: 2
 ### Zync Deployment Env
-zync_env_rails_log_to_stdout: false
 zync_env_rails_env: "development"
 ### Zync Deployment Resources
 zync_resources_requests_cpu: "250m"
@@ -29,7 +28,6 @@ zync_readiness_probe_failure_threshold: 3
 ## Zync-Que Deployment
 que_replicas: 2
 ### Zync Deployment Env
-que_env_rails_log_to_stdout: false
 que_env_rails_env: "development"
 ### Zync-Que Deployment Resources
 que_resources_requests_cpu: "250m"

--- a/roles/zync/defaults/main.yml
+++ b/roles/zync/defaults/main.yml
@@ -7,7 +7,7 @@ image_tag: "nightly"
 zync_replicas: 2
 ### Zync Deployment Env
 zync_env_rails_log_to_stdout: false
-zync_env_rails_env: dev
+zync_env_rails_env: "development"
 ### Zync Deployment Resources
 zync_resources_requests_cpu: "250m"
 zync_resources_requests_memory: "250Mi"
@@ -30,7 +30,7 @@ zync_readiness_probe_failure_threshold: 3
 que_replicas: 2
 ### Zync Deployment Env
 que_env_rails_log_to_stdout: false
-que_env_rails_env: dev
+que_env_rails_env: "development"
 ### Zync-Que Deployment Resources
 que_resources_requests_cpu: "250m"
 que_resources_requests_memory: "250Mi"

--- a/roles/zync/defaults/main.yml
+++ b/roles/zync/defaults/main.yml
@@ -8,7 +8,6 @@ zync_replicas: 3
 ### Zync Deployment Env
 zync_env_rails_log_to_stdout: false
 zync_env_rails_env: dev
-zync_env_db_wait_sleep_seconds: 30
 ### Zync Deployment Resources
 zync_resources_requests_cpu: "250m"
 zync_resources_requests_memory: "250Mi"

--- a/roles/zync/templates/zync-deployment.yaml
+++ b/roles/zync/templates/zync-deployment.yaml
@@ -28,33 +28,6 @@ spec:
       imagePullSecrets:
         - name: "{{ image.pull_secret_name }}"
 {% endif %}
-      initContainers:
-      # initContainers > zync-db-svc
-        - name: zync-db-svc
-          image: "{{ image.name | default(image_name) }}:{{ image.tag | default(image_tag) }}"
-          imagePullPolicy: Always
-          command:
-            - bash
-            - -c
-            - bundle exec sh -c "until rake boot:db; do sleep $SLEEP_SECONDS; done"
-        ## initContainers > zync-db-svc > env
-          env:
-            - name: SLEEP_SECONDS
-              value: "{{ zync.env.db_wait_sleep_seconds | default(zync_env_db_wait_sleep_seconds) }}"
-          ### secret/zync
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  key: DB_URL
-                  name: zync
-        ## initContainers > zync-db-svc > resources
-          resources:
-            requests:
-              memory: "{{ zync.resources.requests.memory | default(zync_resources_requests_memory) }}"
-              cpu: "{{ zync.resources.requests.cpu | default(zync_resources_requests_cpu) }}"
-            limits:
-              memory: "{{ zync.resources.limits.memory | default(zync_resources_limits_memory) }}"
-              cpu: "{{ zync.resources.limits.cpu | default(zync_resources_limits_cpu) }}"
       containers:
       # containers > zync
         - name: zync

--- a/roles/zync/templates/zync-deployment.yaml
+++ b/roles/zync/templates/zync-deployment.yaml
@@ -74,7 +74,7 @@ spec:
         ## containers > zync > env
           env:
           - name: RAILS_LOG_TO_STDOUT
-            value: "{{ zync.env.rails_log_to_stdout | default(zync_env_rails_log_to_stdout) }}"
+            value: "true"
           - name: RAILS_ENV
             value: "{{ zync.env.rails_env | default(zync_env_rails_env) }}"
           - name: POD_NAME

--- a/roles/zync/templates/zync-que-deployment.yaml
+++ b/roles/zync/templates/zync-que-deployment.yaml
@@ -73,7 +73,7 @@ spec:
         ## containers > zync-que > env
           env:
           - name: RAILS_LOG_TO_STDOUT
-            value: "{{ que.env.rails_log_to_stdout | default(que_env_rails_log_to_stdout) }}"
+            value: "true"
           - name: RAILS_ENV
             value: "{{ que.env.rails_env | default(que_env_rails_env) }}"
           - name: POD_NAME


### PR DESCRIPTION
Solves part of https://github.com/3scale/platform/issues/235
 - Remove zync init container  (there was an init container which just check basic DB connectivity, just present on zync deployment, while both deployments connect to same postgres DB). We are removing that kind of init containers from 3scale saas, as DB connectivity is always needed, not just on pod startup. Actually, on a possible rolling update process, if there is no DB connection, new pods won't pass liveness/readiness healthchecks, so new pods won't be promoted for example.
- Remove var `dbWaitSleepSeconds` (was only used on removed init container)
- Match default number of replicas to current documentation
- Document only accepted value on `railsEnv` var ([test/development/production](https://github.com/3scale/zync/tree/62f054e712b8961eaccb7eb0b02fc7bdad0a08a8/config/environments)), leave default value to `development`), otherwise when pod starts it complains about:
```
onfig.eager_load is set to nil. 
Please update your config/environments/*.rb files accordingly: 
* development - set it to false 
* test - set it to false (unless you use a tool that preloads your test environment) 
* production - set it to true
```
- Remove possibility to change `railsLogsToStdout`: 3scale product already enables it by default and cannot be tuned, it seems it just changes the logger format, and there is no reason to not have it always enabled. In addition,  it is only used on production environment (RAILS_ENV=production), which is the only environment value possible for serious zync deployments (staging/production...), because it enables all zync features. Actually, although it is used as a boolean, [zync app just checks if var is present, independently from the value](https://github.com/3scale/zync/blob/d26abd66b41470aae949484532d6501a4808e17c/config/environments/production.rb#L64).