### PR TITLE
Feature/Add echoapi controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else ifeq (${UNAME}, Darwin)
   INPLACE_SED=sed -i ""
 endif
 
-TAG ?= v0.4.0
+TAG ?= v0.5.0
 REGISTRY ?= quay.io
 ORG ?= 3scale
 PROJECT ?= 3scale-saas-operator

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ operator-deploy: namespace-create ## OPERATOR DEPLOY - Deploy Operator objects (
 	$(KUBE_CLIENT) apply -f deploy/crds/saas.3scale.net_backends_crd.yaml --validate=false || true
 	$(KUBE_CLIENT) apply -f deploy/crds/saas.3scale.net_zyncs_crd.yaml --validate=false || true
 	$(KUBE_CLIENT) apply -f deploy/crds/saas.3scale.net_corsproxies_crd.yaml --validate=false || true
+	$(KUBE_CLIENT) apply -f deploy/crds/saas.3scale.net_echoapis_crd.yaml --validate=false || true
 	$(KUBE_CLIENT) apply -f deploy/service_account.yaml -n $(NAMESPACE)
 	$(KUBE_CLIENT) apply -f deploy/role.yaml -n $(NAMESPACE)
 	$(KUBE_CLIENT) apply -f deploy/role_binding.yaml -n $(NAMESPACE)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Current 3scale SaaS controllers supported:
 * Backend
 * Zync
 * CORSProxy
+* EchoAPI
 
 Future 3scale SaaS controllers to be added:
 * System
@@ -23,6 +24,8 @@ Future 3scale SaaS controllers to be added:
 * [prometheus-operator](https://github.com/coreos/prometheus-operator) v0.17.0+
 * [grafana-operator](https://github.com/integr8ly/grafana-operator) v3.0.0+
 * [secrets-manager](https://github.com/tuenti/secrets-manager) v1.0.2+
+* [marin3r](https://github.com/3scale/marin3r) v0.4.0+
+* [aws-nlb-helper-operator](https://github.com/3scale/aws-nlb-helper-operator) v0.2.0+
 
 ## Documentation
 
@@ -31,6 +34,7 @@ Future 3scale SaaS controllers to be added:
 * [Backend Custom Resource Reference](docs/backend-crd-reference.md)
 * [Zync Custom Resource Reference](docs/zync-crd-reference.md)
 * [CORSProxy Custom Resource Reference](docs/corsproxy-crd-reference.md)
+* [EchoAPI Custom Resource Reference](docs/echoapi-crd-reference.md)
 
 ## License
 

--- a/deploy/crds/saas.3scale.net_echoapis_crd.yaml
+++ b/deploy/crds/saas.3scale.net_echoapis_crd.yaml
@@ -1,0 +1,145 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: echoapis.saas.3scale.net
+spec:
+  group: saas.3scale.net
+  names:
+    kind: EchoAPI
+    listKind: EchoAPIList
+    plural: echoapis
+    singular: echoapi
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: EchoAPI is the Schema for EchoAPI instance
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+          description: EchoAPISpec defines the desired state of EchoAPI
+          required:
+          - externalDnsHostname
+          - marin3r
+          - deploymentAnnotations
+          properties:
+            image:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Image name (docker repository)
+                tag:
+                  type: string
+                  description: Image tag
+                pullSecretName:
+                  type: string
+                  description: Quay pull secret for private repository
+            replicas:
+              type: integer
+              description: Number of replicas
+            resources:
+              type: object
+              properties:
+                requests:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: "[0-9]+m?$"
+                      description: Override CPU requests
+                    memory:
+                      type: string
+                      pattern: "[0-9]+([kKmMgGtTpPeE]i?)?$"
+                      description: Override Memory requests
+                limits:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: "[0-9]+m?$"
+                      description: Override CPU limits
+                    memory:
+                      type: string
+                      pattern: "[0-9]+([kKmMgGtTpPeE]i?)?$"
+                      description: Override Memory limits
+            livenessProbe:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  type: integer
+                  description: Override liveness probe initial delay (seconds)
+                timeoutSeconds:
+                  type: integer
+                  description: Override liveness probe timeout (seconds)
+                periodSeconds:
+                  type: integer
+                  description: Override liveness probe period (seconds)
+                successThreshold:
+                  type: integer
+                  description: Override liveness probe success threshold
+                failureThreshold:
+                  type: integer
+                  description: Override liveness probe failure threshold
+            readinessProbe:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  type: integer
+                  description: Override readiness probe initial delay (seconds)
+                timeoutSeconds:
+                  type: integer
+                  description: Override readiness probe timeout (seconds)
+                periodSeconds:
+                  type: integer
+                  description: Override readiness probe period (seconds)
+                successThreshold:
+                  type: integer
+                  description: Override readiness probe success threshold
+                failureThreshold:
+                  type: integer
+                  description: Override readiness probe failure threshold
+            externalDnsHostname:
+              type: string
+              description: DNS hostnames to manage on AWS Route53 by external-dns
+            marin3r:
+              type: object
+              required:
+              - enabled
+              properties:
+                enabled:
+                  type: boolean
+                  description:  Enable (true) or disable (false) marin3r
+            deploymentAnnotations:
+              additionalProperties:
+                type: string
+              description: Map of deployment annotations
+              type: object
+            loadBalancer:
+              type: object
+              properties:
+                proxyProtocol:
+                  type: boolean
+                  description:  Enable (true) or disable (false) proxy protocol with aws-nlb-helper-operator
+                crossZoneLoadBalancingEnabled:
+                  type: boolean
+                  description: Enable (true) or disable (false) cross zone load balancing
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/crds/saas.3scale.net_v1alpha1_echoapi_cr.yaml
+++ b/deploy/crds/saas.3scale.net_v1alpha1_echoapi_cr.yaml
@@ -1,0 +1,14 @@
+apiVersion: saas.3scale.net/v1alpha1
+kind: EchoAPI
+metadata:
+  name: example
+spec:
+  image:
+    tag: v1.0.1
+  replicas: 1
+  externalDnsHostname: echo-api.example.3scale.net
+  marin3r:
+    enabled: true
+  deploymentAnnotations:
+    marin3r.3scale.net/node-id: echo-api
+    marin3r.3scale.net/ports: echo-api-http:38080,echo-api-https:38443,envoy-metrics:9901

--- a/docs/echoapi-crd-reference.md
+++ b/docs/echoapi-crd-reference.md
@@ -1,0 +1,93 @@
+# EchoAPI Custom Resource Reference
+
+## Simple CR Example
+
+```yaml
+apiVersion: saas.3scale.net/v1alpha1
+kind: EchoAPI
+metadata:
+  name: simple-example
+spec:
+  image:
+    tag: v1.0.1
+  replicas: 1
+  externalDnsHostname: echo-api.example.3scale.net
+  marin3r:
+    enabled: true
+  deploymentAnnotations:
+    marin3r.3scale.net/node-id: echo-api
+    marin3r.3scale.net/ports: echo-api-http:38080,echo-api-https:38443,envoy-metrics:9901
+```
+
+## Full CR Example
+
+Most of the fields do not need to be specified (can use default values), this is just an example of everything that can be overriden under your own risk:
+
+```yaml
+apiVersion: saas.3scale.net/v1alpha1
+kind: EchoAPI
+metadata:
+  name: full-example
+spec:
+  image:
+    name: quay.io/3scale/echoapi
+    tag: v1.0.1
+    pullSecretName: quay-pull-secret
+  replicas: 2
+  livenessProbe:
+    initialDelaySeconds: 25
+    timeoutSeconds: 2
+    periodSeconds: 20
+    successThreshold: 1
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 25
+    timeoutSeconds: 2
+    periodSeconds: 20
+    successThreshold: 1
+    failureThreshold: 5
+  resources:
+    requests:
+      cpu: "75m"
+      memory: "64Mi"
+    limits:
+      cpu: "150m"
+      memory: "128Mi"
+  externalDnsHostname: echo-api.example.3scale.net
+  marin3r:
+    enabled: true
+  deploymentAnnotations:
+    marin3r.3scale.net/node-id: echo-api
+    marin3r.3scale.net/ports: echo-api-http:38080,echo-api-https:38443,envoy-metrics:9901
+  loadBalancer:
+    proxyProtocol: true
+    crossZoneLoadBalancingEnabled: true
+```
+
+## CR Spec
+
+| **Field** | **Type** | **Required** | **Default value** | **Description** |
+|:---:|:---:|:---:|:---:|:---:|
+| `image.name` | `string` | No | `quay.io/3scale/echoapi` | Image name (docker repository) |
+| `image.tag` | `string` | No | `latest` | Image tag |
+| `image.pullSecretName` | `string` | No | - | Quay pull secret for private repository |
+| `replicas` | `int` | No | `2` | Number of replicas |
+| `resources.requests.cpu` | `string` | No | `50m` | Override CPU requests |
+| `resources.requests.memory` | `string` | No | `40Mi` | Override Memory requests |
+| `resources.limits.cpu` | `string` | No | `150m` | Override CPU limits |
+| `resources.limits.memory` | `string` | No | `80Mi` | Override Memory limits |
+| `livenessProbe.initialDelaySeconds` | `int` | No | `5` | Override liveness initial delay (seconds) |
+| `livenessProbe.timeoutSeconds` | `int` | No | `5` | Override liveness timeout (seconds) |
+| `livenessProbe.periodSeconds` | `int` | No | `10` | Override liveness period (seconds) |
+| `livenessProbe.successThreshold` | `int` | No | `1` | Override liveness success threshold |
+| `livenessProbe.failureThreshold` | `int` | No | `3` | Override liveness failure threshold |
+| `readinessProbe.initialDelaySeconds` | `int` | No | `5` | Override readiness initial delay (seconds) |
+| `readinessProbe.timeoutSeconds` | `int` | No | `5` | Override readiness timeout (seconds) |
+| `readinessProbe.periodSeconds` | `int` | No | `30` | Override readiness period (seconds) |
+| `readinessProbe.successThreshold` | `int` | No | `1` | Override readiness success threshold |
+| `readinessProbe.failureThreshold` | `int` | No | `3` | Override readiness failure threshold |
+| `externalDnsHostname` | `string` | Yes | - | DNS hostnames to manage on AWS Route53 by external-dns |
+| `marin3r.enabled` | `boolean` | Yes | - | Enable (`true`) or disable (`false`) marin3r |
+| `deploymentAnnotations.{}` | `map` | Yes | - | Map of deployment annotations |
+| `loadBalancer.proxyProtocol` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) proxy protocol with aws-nlb-helper-operator |
+| `loadBalancer.crossZoneLoadBalancingEnabled` | `bool` | No | `true` | Enable (`true`) or disable (`false`) cross zone load balancing |

--- a/roles/echoapi/defaults/main.yml
+++ b/roles/echoapi/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+
+## Deployment
+replicas: 2
+image_name: "quay.io/3scale/echoapi"
+image_tag: "latest"
+liveness_probe_initial_delay_seconds: 5
+liveness_probe_timeout_seconds: 5
+liveness_probe_period_seconds: 10
+liveness_probe_success_threshold: 1
+liveness_probe_failure_threshold: 3
+readiness_probe_initial_delay_seconds: 5
+readiness_probe_timeout_seconds: 5
+readiness_probe_period_seconds: 30
+readiness_probe_success_threshold: 1
+readiness_probe_failure_threshold: 3
+resources_requests_cpu: "50m"
+resources_requests_memory: "40Mi"
+resources_limits_cpu: "150m"
+resources_limits_memory: "80Mi"
+
+## Service
+load_balancer_proxy_protocol: true
+load_balancer_cross_zone_load_balancing_enabled: true

--- a/roles/echoapi/meta/main.yml
+++ b/roles/echoapi/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  author: 3scale SRE team
+  description: 3scale echoapi component
+  company: Red Hat
+  license: license (GPLv2, CC-BY, etc)
+  min_ansible_version: 2.9
+  galaxy_tags: []
+dependencies: []
+collections:
+- operator_sdk.util
+- community.kubernetes

--- a/roles/echoapi/tasks/main.yml
+++ b/roles/echoapi/tasks/main.yml
@@ -12,3 +12,7 @@
 - name: Manage echo-api Service for EchoAPI {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     definition: "{{ lookup('template', 'echo-api-service.yaml') }}"
+
+- name: Manage echo-api PodMonitor for EchoAPI {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    definition: "{{ lookup('template', 'echo-api-podmonitor.yaml') }}"

--- a/roles/echoapi/tasks/main.yml
+++ b/roles/echoapi/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+
+
+- name: Fix deploymentAnnotations map var that may contain originally hyphens but ansible has converted to underscore
+  set_fact:
+    deployment_annotations_clean: "{{ deployment_annotations | regex_replace ('_','-') }}"
+
+- name: Manage echo-api Deployment for EchoAPI {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    definition: "{{ lookup('template', 'echo-api-deployment.yaml') }}"
+
+- name: Manage echo-api Service for EchoAPI {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    definition: "{{ lookup('template', 'echo-api-service.yaml') }}"

--- a/roles/echoapi/templates/echo-api-deployment.yaml
+++ b/roles/echoapi/templates/echo-api-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-api
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: echo-api
+    threescale_component: echo-api
+    threescale_component_element: echo-api
+spec:
+  replicas: {{ replicas }}
+  selector:
+    matchLabels:
+      deployment: echo-api
+  template:
+    metadata:
+      labels:
+        deployment: echo-api
+        app: echo-api
+        threescale_component: echo-api
+        threescale_component_element: echo-api
+{% if marin3r.enabled is defined and marin3r.enabled == true %}
+        marin3r.3scale.net/status: "enabled"
+{% endif %}
+      annotations: {{ deployment_annotations_clean }}
+    spec:
+{% if image.pull_secret_name is defined %}
+      imagePullSecrets:
+        - name: "{{ image.pull_secret_name | default(image_pull_secret_name) }}"
+{% endif %}
+      containers:
+        - name: echo-api
+          image: "{{ image.name | default(image_name) }}:{{ image.tag | default(image_tag) }}"
+          ports:
+            - name: echo-api
+              containerPort: 9292
+          resources:
+            requests:
+              memory: "{{ resources.requests.memory | default(resources_requests_memory) }}"
+              cpu: "{{ resources.requests.cpu | default(resources_requests_cpu) }}"
+            limits:
+              memory: "{{ resources.limits.memory | default(resources_limits_memory) }}"
+              cpu: "{{ resources.limits.cpu | default(resources_limits_cpu) }}"
+          livenessProbe:
+            tcpSocket:
+              port: echo-api
+            initialDelaySeconds: {{ liveness_probe.initial_delay_seconds | default(liveness_probe_initial_delay_seconds) }}
+            timeoutSeconds: {{ liveness_probe.timeout_seconds | default(liveness_probe_timeout_seconds) }}
+            periodSeconds: {{ liveness_probe.period_seconds | default (liveness_probe_period_seconds) }}
+            successThreshold: {{ liveness_probe.success_threshold | default(liveness_probe_success_threshold) }}
+            failureThreshold: {{ liveness_probe.failure_threshold | default(liveness_probe_failure_threshold) }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: echo-api
+              scheme: HTTP
+            initialDelaySeconds: {{ readiness_probe.initial_delay_seconds | default(readiness_probe_initial_delay_seconds) }}
+            timeoutSeconds: {{ readiness_probe.timeout_seconds | default(readiness_probe_timeout_seconds) }}
+            periodSeconds: {{ readiness_probe.period_seconds | default(readiness_probe_period_seconds) }}
+            successThreshold: {{ readiness_probe.success_threshold | default(readiness_probe_success_threshold) }}
+            failureThreshold: {{ readiness_probe.failure_threshold | default(readiness_probe_failure_threshold) }}
+

--- a/roles/echoapi/templates/echo-api-podmonitor.yaml
+++ b/roles/echoapi/templates/echo-api-podmonitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: echo-api
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: echo-api
+    threescale_component: echo-api
+    threescale_component_element: echo-api
+spec:
+  podMetricsEndpoints:
+    - interval: 30s
+      path: /stats/prometheus
+      port: envoy-metrics
+      relabelings:
+        - sourceLabels:
+            - __meta_kubernetes_service_label_app
+          targetLabel: app
+  selector:
+    matchLabels:
+      deployment: echo-api

--- a/roles/echoapi/templates/echo-api-service.yaml
+++ b/roles/echoapi/templates/echo-api-service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-api
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: echo-api
+    threescale_component: echo-api
+    threescale_component_element: echo-api
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "{{ external_dns_hostname }}"
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "{{ load_balancer.cross_zone_load_balancing_enabled | default (load_balancer_cross_zone_load_balancing_enabled) }}"
+    aws-nlb-helper.3scale.net/enable-targetgroups-proxy-protocol: "{{ load_balancer.proxy_protocol | default (load_balancer_proxy_protocol) }}"
+spec:
+  type: LoadBalancer
+  selector:
+    deployment: echo-api
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: echo-api-http
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: echo-api-https

--- a/watches.yaml
+++ b/watches.yaml
@@ -18,3 +18,8 @@
   group: saas.3scale.net
   kind: CORSProxy
   role: corsproxy
+
+- version: v1alpha1
+  group: saas.3scale.net
+  kind: EchoAPI
+  role: echoapi


### PR DESCRIPTION
Closes https://github.com/3scale/saas-operator/issues/14

- Add EchoAPI controller, using all yamls from [staging environment](https://github.com/3scale/platform/tree/3a3b83ebb3fc05e090e1b55b237a7608169625da/kubernetes/stg-saas-ocp4-3/3scale/echo-api) 
- Bump operator version to `v0.5.0`
- By the moment, EnvoyConfig is out of the operator (until it gets simplified, so not full envoy raw config, we plan to do maybe lots of changes here in the near future)
- Instead of having marin3r deployment annotations being managed by specific CR fields, taking into account that marin3r is in development work in progress mode, annotations are managed by a free-form CR field of type `map` called `deploymentAnnotations`, where you can add any key/value annotations (will make easier to progress on marin3r without having to update the saas-operator). Because of ansible python jinja templating converts any key inside the map containing hyphens like `marin3r.3scale.net/node-id: echo-api` to underscore `marin3r.3scale.net/node_id: echo-api` , the first ansible task of the role is a task converting any annotation with underscore to hyphen again (this will change once we have defined all possible final annotations on marin3r operator)
