### PR TITLE
Remove autossl possibility to configure s3 logging at AWS ELB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else ifeq (${UNAME}, Darwin)
   INPLACE_SED=sed -i ""
 endif
 
-TAG ?= v0.5.0
+TAG ?= v0.5.1
 REGISTRY ?= quay.io
 ORG ?= 3scale
 PROJECT ?= 3scale-saas-operator

--- a/deploy/crds/saas.3scale.net_autossls_crd.yaml
+++ b/deploy/crds/saas.3scale.net_autossls_crd.yaml
@@ -178,18 +178,6 @@ spec:
                 connectionHealthcheckTimeout:
                   type: integer
                   description: Connection healthcheck timeout (seconds)
-                accessLogEnabled:
-                  type: boolean
-                  description: Enable (true) or disable (false) s3 access logs
-                accessLogEmitInterval:
-                  type: integer
-                  description: Access logs emit interval (minutes)
-                accessLogS3BucketName:
-                  type: string
-                  description: Access logs s3 bucket name
-                accessLogS3BucketPrefix:
-                  type: string
-                  description: Access logs s3 bucket prefix
             grafanaDashboard:
               type: object
               properties:

--- a/deploy/crds/saas.3scale.net_v1alpha1_autossl_cr.yaml
+++ b/deploy/crds/saas.3scale.net_v1alpha1_autossl_cr.yaml
@@ -14,8 +14,3 @@ spec:
     domainWhitelist: autossl.example.3scale.net
     redisHost: example-autossl-redis.ng.0001.use1.cache.amazonaws.com
   externalDnsHostname: mtssl-edge-a.example.3scale.net,mtssl-edge-b.example.3scale.net,autossl.example.3scale.net
-  loadBalancer:
-    accessLogEnabled: true
-    accessLogEmitInterval: 5
-    accessLogS3BucketName: s3-bucket-example-logs
-    accessLogS3BucketPrefix: example-cluster/autossl

--- a/docs/autossl-crd-reference.md
+++ b/docs/autossl-crd-reference.md
@@ -75,10 +75,6 @@ spec:
     connectionHealthcheckUnhealthyThreshold: 2
     connectionHealthcheckInterval: 5
     connectionHealthcheckTimeout: 3
-    accessLogEnabled: true
-    accessLogEmitInterval: 5
-    accessLogS3BucketName: s3-bucket-example-logs
-    accessLogS3BucketPrefix: example-cluster/autossl
   grafanaDashboard:
     label:
       key: discovery
@@ -125,9 +121,5 @@ spec:
 | `loadBalancer.connectionHealthcheckUnhealthyThreshold` | `int` | No | `2` | Connection healthcheck unhealthy threshold |
 | `loadBalancer.connectionHealthcheckInterval` | `int` | No | `5` | Connection healthcheck interval (seconds) |
 | `loadBalancer.connectionHealthcheckTimeout` | `int` | No | `3` | Connection healthcheck timeout (seconds) |
-| `loadBalancer.accessLogEnabled` | `bool` | No | - | Enable (`true`) or disable (`false`) s3 access logs |
-| `loadBalancer.accessLogEmitInterval` | `int` | No | - | Access logs emit interval (minutes) |
-| `loadBalancer.accessLogS3BucketName` | `string` | No | (only if enabled) | Access logs s3 bucket name |
-| `loadBalancer.accessLogS3BucketPrefix` | `string` | No | (only if enabled) | Access logs s3 bucket prefix |
 | `grafanaDashboard.label.key` | `string` | No | `monitoring-key` | Label `key` used by grafana-operator for dashboard discovery |
 | `grafanaDashboard.label.value` | `string` | No | `middleware` | Label `value` used by grafana-operator for dashboard discovery |

--- a/roles/autossl/templates/autossl-service.yaml
+++ b/roles/autossl/templates/autossl-service.yaml
@@ -16,18 +16,6 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold: "{{ load_balancer.connection_healthcheck_unhealthy_threshold | default (load_balancer_connection_healthcheck_unhealthy_threshold) }}"
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: "{{ load_balancer.connection_healthcheck_interval | default (load_balancer_connection_healthcheck_interval) }}" 
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout: "{{ load_balancer.connection_healthcheck_timeout | default (load_balancer_connection_healthcheck_timeout) }}"
-{% if load_balancer.access_log_enabled is defined and load_balancer.access_log_enabled == true %}
-    service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: "{{ load_balancer.access_log_enabled }}"
-{% if load_balancer.access_log_emit_interval is defined %}
-    service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: "{{ load_balancer.access_log_emit_interval }}"
-{% endif %}
-{% if load_balancer.access_log_s3_bucket_name is defined %}
-    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: "{{ load_balancer.access_log_s3_bucket_name }}"
-{% endif %}
-{% if load_balancer.access_log_s3_bucket_prefix is defined %}
-    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: "{{ load_balancer.access_log_s3_bucket_prefix }}"
-{% endif %}
-{% endif %}
 spec:
   type: LoadBalancer
   ports:


### PR DESCRIPTION
AutoSSL needs to have proxy-protocol enabled at AWS ELB, and having proxy protocol enabled make totally unnecessary to have s3 logging configured at AWS ELB.