### PR TITLE
feat: add cluster role aggregations

### DIFF
--- a/deploy/clusterrole-aggregations/saas.3scale.net_apicasts.yaml
+++ b/deploy/clusterrole-aggregations/saas.3scale.net_apicasts.yaml
@@ -1,0 +1,38 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-apicasts-admin-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - apicasts
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+    - deletecollection
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-apicasts-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - apicasts
+  verbs:
+    - get
+    - list
+    - watch

--- a/deploy/clusterrole-aggregations/saas.3scale.net_autossls.yaml
+++ b/deploy/clusterrole-aggregations/saas.3scale.net_autossls.yaml
@@ -1,0 +1,38 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-autossl-admin-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - autossls
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+    - deletecollection
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-autossl-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - autossls
+  verbs:
+    - get
+    - list
+    - watch

--- a/deploy/clusterrole-aggregations/saas.3scale.net_backends.yaml
+++ b/deploy/clusterrole-aggregations/saas.3scale.net_backends.yaml
@@ -1,0 +1,38 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-backends-admin-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - backends
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+    - deletecollection
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-backends-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - backends
+  verbs:
+    - get
+    - list
+    - watch

--- a/deploy/clusterrole-aggregations/saas.3scale.net_corsproxies.yaml
+++ b/deploy/clusterrole-aggregations/saas.3scale.net_corsproxies.yaml
@@ -1,0 +1,38 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-corsproxies-admin-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - corsproxies
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+    - deletecollection
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-corsproxies-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - corsproxies
+  verbs:
+    - get
+    - list
+    - watch

--- a/deploy/clusterrole-aggregations/saas.3scale.net_echoapis.yaml
+++ b/deploy/clusterrole-aggregations/saas.3scale.net_echoapis.yaml
@@ -1,0 +1,38 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-echoapis-admin-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - echoapis
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+    - deletecollection
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-echoapis-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - echoapis
+  verbs:
+    - get
+    - list
+    - watch

--- a/deploy/clusterrole-aggregations/saas.3scale.net_mappingservice.yaml
+++ b/deploy/clusterrole-aggregations/saas.3scale.net_mappingservice.yaml
@@ -1,0 +1,38 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-mappingservice-admin-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - mappingservice
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+    - deletecollection
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-mappingservice-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - mappingservice
+  verbs:
+    - get
+    - list
+    - watch

--- a/deploy/clusterrole-aggregations/saas.3scale.net_zyncs.yaml
+++ b/deploy/clusterrole-aggregations/saas.3scale.net_zyncs.yaml
@@ -1,0 +1,38 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-zyncs-admin-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - zyncs
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+    - deletecollection
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-zyncs-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+    - saas.3scale.net
+  resources:
+    - zyncs
+  verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
Allows using default `admin`, `view` and `edit` cluster roles for accessing the `saas.3scale.net` resources.