### PR TITLE
fix: Remove wildcard from saas.3scale.net role rule

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -112,7 +112,13 @@ rules:
 - apiGroups:
   - saas.3scale.net
   resources:
-  - '*'
+  - apicasts
+  - autossls
+  - backends
+  - corsproxies
+  - echoapis
+  - mappingservice
+  - zyncs
   verbs:
   - create
   - delete


### PR DESCRIPTION
Using `*` can lead to issues when trying to create a role when the service account is not using a wildcard ruleset:

```
roles.rbac.authorization.k8s.io "threescale-saas-operator" is forbidden: user "system:serviceaccount:default:argocd-manager" (groups=["system:serviceaccounts" "system:serviceaccounts:default" "system:authenticated"]) is attempting to grant RBAC permissions not currently held: 
```