### PR TITLE
Feature/Add HA to backend controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ namespace-create: # NAMESPACE MANAGEMENT - Create namespace for the operator
 	$(KUBE_CLIENT) create namespace $(NAMESPACE) || true
 	$(KUBE_CLIENT) label namespace $(NAMESPACE) monitoring-key=middleware || true
 
+operator-local-deploy: namespace-create ## OPERATOR LOCAL DEPLOY - Deploy Operator locally for dev purpose
+	operator-sdk run --local --watch-namespace $(NAMESPACE)
+
 operator-deploy: namespace-create ## OPERATOR DEPLOY - Deploy Operator objects (namespace, CRDs, service account, role, role binding and operator deployment)
 	$(KUBE_CLIENT) apply -f deploy/crds/saas.3scale.net_autossls_crd.yaml --validate=false || true
 	$(KUBE_CLIENT) apply -f deploy/crds/saas.3scale.net_backends_crd.yaml --validate=false || true

--- a/deploy/crds/saas.3scale.net_backends_crd.yaml
+++ b/deploy/crds/saas.3scale.net_backends_crd.yaml
@@ -131,9 +131,42 @@ spec:
                     eipAllocations:
                       type: string
                       description: Optional Elastic IPs allocations
+                pdb:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) PodDisruptionBudget
+                    maxUnavailable:
+                      type: string
+                      description: Maximum number of unavailable pods (number or percentage of pods)
+                    minAvailable:
+                      type: string
+                      description: Minimum number of available pods (number or percentage of pods)
+                hpa:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) HoritzontalPodAutoscaler
+                    minReplicas:
+                      type: integer
+                      description: Minimum number of replicas
+                    maxReplicas:
+                      type: integer
+                      description: Maximum number of replicas
+                    resourceName:
+                      type: string
+                      description: Resource used for autoscale (cpu/memory)
+                      enum:
+                      - cpu
+                      - memory
+                    resourceUtilization:
+                      type: integer
+                      description: Percentage usage of the resource used for autoscale
                 replicas:
                   type: integer
-                  description: Number of replicas
+                  description: Number of replicas (ignored if hpa is enabled)
                 env:
                   type: object
                   description: Environment variables
@@ -211,9 +244,42 @@ spec:
             worker:
               type: object
               properties:
+                pdb:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) PodDisruptionBudget
+                    maxUnavailable:
+                      type: string
+                      description: Maximum number of unavailable pods (number or percentage of pods)
+                    minAvailable:
+                      type: string
+                      description: Minimum number of available pods (number or percentage of pods)
+                hpa:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) HoritzontalPodAutoscaler
+                    minReplicas:
+                      type: integer
+                      description: Minimum number of replicas
+                    maxReplicas:
+                      type: integer
+                      description: Maximum number of replicas
+                    resourceName:
+                      type: string
+                      description: Resource used for autoscale (cpu/memory)
+                      enum:
+                      - cpu
+                      - memory
+                    resourceUtilization:
+                      type: integer
+                      description: Percentage usage of the resource used for autoscale
                 replicas:
                   type: integer
-                  description: Number of replicas
+                  description: Number of replicas (ignored if hpa is enabled)
                 env:
                   type: object
                   description: Environment variables

--- a/deploy/crds/saas.3scale.net_backends_crd.yaml
+++ b/deploy/crds/saas.3scale.net_backends_crd.yaml
@@ -142,7 +142,7 @@ spec:
                       description: Maximum number of unavailable pods (number or percentage of pods)
                     minAvailable:
                       type: string
-                      description: Minimum number of available pods (number or percentage of pods)
+                      description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
                 hpa:
                   type: object
                   properties:
@@ -255,7 +255,7 @@ spec:
                       description: Maximum number of unavailable pods (number or percentage of pods)
                     minAvailable:
                       type: string
-                      description: Minimum number of available pods (number or percentage of pods)
+                      description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
                 hpa:
                   type: object
                   properties:

--- a/docs/backend-crd-reference.md
+++ b/docs/backend-crd-reference.md
@@ -112,7 +112,6 @@ spec:
     pdb:
       enabled: true
       minAvailable: "80%"
-    replicas: 2
     env:
       logFormat: json
       redisAsync: false
@@ -166,7 +165,7 @@ spec:
 | `errorMonitoringEnabled` | `bool` | No | `false` | Mount (`true`) or not (`false`) backend-error-monitoring Secret on deployments |
 | `listener.externalDnsHostname` | `string` | Yes | - | DNS hostnames to manage on AWS Route53 by external-dns |
 | `listener.marin3r.enabled` | `boolean` | Yes | - | Enable (`true`) or disable (`false`) marin3r |
-| `listener.marin3r.anotations.{}` | `map` | No | - | Map of marin3r annotations |
+| `listener.marin3r.annotations.{}` | `map` | No | - | Map of marin3r annotations |
 | `listener.loadBalancer.proxyProtocol` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) proxy protocol with aws-nlb-helper-operator |
 | `listener.loadBalancer.crossZoneLoadBalancingEnabled` | `bool` | No | `true` | Enable (`true`) or disable (`false`) cross zone load balancing |
 | `listener.loadBalancer.eipAllocations` | `string` | No | - | Optional Elastic IPs allocations |

--- a/docs/backend-crd-reference.md
+++ b/docs/backend-crd-reference.md
@@ -70,7 +70,16 @@ spec:
       proxyProtocol: true
       crossZoneLoadBalancingEnabled: true
       eipAllocations: "eipalloc-080ecfaf74a799b24,eipalloc-098963e814413a5d1,eipalloc-02bd497572f4321a0"
-    replicas: 2
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 4
+      resourceName: cpu
+      resourceUtilization: 90
+    pdb:
+      enabled: true
+      maxUnavailable: "1"
+      minAvailable: "2"
     env:
       logFormat: json
       redisAsync: false
@@ -95,6 +104,16 @@ spec:
         cpu: "1"
         memory: "700Mi"
   worker:
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 4
+      resourceName: cpu
+      resourceUtilization: 90
+    pdb:
+      enabled: true
+      maxUnavailable: "10%"
+      minAvailable: "2"
     replicas: 2
     env:
       logFormat: json
@@ -153,7 +172,15 @@ spec:
 | `listener.loadBalancer.proxyProtocol` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) proxy protocol with aws-nlb-helper-operator |
 | `listener.loadBalancer.crossZoneLoadBalancingEnabled` | `bool` | No | `true` | Enable (`true`) or disable (`false`) cross zone load balancing |
 | `listener.loadBalancer.eipAllocations` | `string` | No | - | Optional Elastic IPs allocations |
-| `listener.replicas` | `int` | No | `1` | Number of replicas |
+| `listener.pdb.enabled` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) PodDisruptionBudget |
+| `listener.pdb.maxUnavailable` | `string` | No | `1` | Maximum number of unavailable pods (number or percentage of pods) |
+| `listener.pdb.minAvailable` | `string` | No | - | Minimum number of available pods (number or percentage of pods) |
+| `listener.hpa.enabled` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) HoritzontalPodAutoscaler |
+| `listener.hpa.minReplicas` | `int` | No | `2` | Minimum number of replicas |
+| `listener.hpa.maxReplicas` | `int` | No | `4` | Maximum number of replicas |
+| `listener.hpa.resourceName` | `string` | No | `cpu` | Resource used for autoscale (cpu/memory) |
+| `listener.hpa.resourceUtilization` | `int` | No | `90` | Percentage usage of the resource used for autoscale |
+| `listener.replicas` | `int` | No | `2` | Number of replicas (ignored if hpa is enabled) |
 | `listener.env.logFormat` | `string` | No | `json` | Log format (`text`/`json`) |
 | `listener.env.listenerWorkers` | `int` | No | `16` | Number of worker processes per listener pod |
 | `listener.env.redisAsync` | `bool` | No | `false` | Enable (`true`) or disable (`false`) redis async mode |
@@ -171,7 +198,15 @@ spec:
 | `listener.readinessProbe.periodSeconds` | `int` | No | `10` | Override readiness period (seconds) |
 | `listener.readinessProbe.successThreshold` | `int` | No | `1` | Override readiness success threshold |
 | `listener.readinessProbe.failureThreshold` | `int` | No | `3` | Override readiness failure threshold |
-| `worker.replicas` | `int` | No | `1` | Number of replicas |
+| `worker.pdb.enabled` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) PodDisruptionBudget |
+| `worker.pdb.maxUnavailable` | `string` | No | `1` | Maximum number of unavailable pods (number or percentage of pods) |
+| `worker.pdb.minAvailable` | `string` | No | - | Minimum number of available pods (number or percentage of pods) |
+| `worker.hpa.enabled` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) HoritzontalPodAutoscaler |
+| `worker.hpa.minReplicas` | `int` | No | `2` | Minimum number of replicas |
+| `worker.hpa.maxReplicas` | `int` | No | `4` | Maximum number of replicas |
+| `worker.hpa.resourceName` | `string` | No | `cpu` | Resource used for autoscale (cpu/memory) |
+| `worker.hpa.resourceUtilization` | `int` | No | `90` | Percentage usage of the resource used for autoscale |
+| `worker.replicas` | `int` | No | `2` | Number of replicas (ignored if hpa is enabled) |
 | `worker.env.logFormat` | `string` | No | `json` | Log format (`text`/`json`) |
 | `worker.env.redisAsync` | `bool` | No | `false` | Enable (`true`) or disable (`false`) redis async mode |
 | `worker.resources.requests.cpu` | `string` | No | `150m` | Override CPU requests |

--- a/docs/backend-crd-reference.md
+++ b/docs/backend-crd-reference.md
@@ -22,7 +22,7 @@ spec:
       enabled: true
       annotations:
         marin3r.3scale.net/node-id: backend-listener
-        marin3r.3scale.net/ports: backend-listener-http:38080,backend-listener-https:38443,envoy-metrics:9901
+        marin3r.3scale.net/ports: backend-listener-http:38080,http-internal:38081,backend-listener-https:38443,envoy-metrics:9901
     replicas: 1
   worker:
     replicas: 1
@@ -65,7 +65,7 @@ spec:
       enabled: true
       annotations:
         marin3r.3scale.net/node-id: backend-listener
-        marin3r.3scale.net/ports: backend-listener-http:38080,backend-listener-https:38443,envoy-metrics:9901
+        marin3r.3scale.net/ports: backend-listener-http:38080,http-internal:38081,backend-listener-https:38443,envoy-metrics:9901
     loadBalancer:
       proxyProtocol: true
       crossZoneLoadBalancingEnabled: true

--- a/roles/backend/defaults/main.yml
+++ b/roles/backend/defaults/main.yml
@@ -18,6 +18,8 @@ config_oauth_max_token_size: "7888"
 config_legacy_referrer_filters: "true"
 
 ## Listener
+listener_pdb_state: "present"
+listener_pdb_max_unavailable: 1
 listener_load_balancer_proxy_protocol: true
 listener_load_balancer_cross_zone_load_balancing_enabled: true
 listener_replicas: 2
@@ -40,6 +42,8 @@ listener_resources_limits_cpu: "1"
 listener_resources_limits_memory: "700Mi"
 
 ## Worker
+worker_pdb_state: "present"
+worker_pdb_max_unavailable: 1
 worker_replicas: 2
 worker_env_log_format: "json"
 worker_env_redis_async: "false"

--- a/roles/backend/defaults/main.yml
+++ b/roles/backend/defaults/main.yml
@@ -20,6 +20,11 @@ config_legacy_referrer_filters: "true"
 ## Listener
 listener_pdb_state: "present"
 listener_pdb_max_unavailable: 1
+listener_hpa_state: "present"
+listener_hpa_min_replicas: 2
+listener_hpa_max_replicas: 4
+listener_hpa_resource_name: "cpu"
+listener_hpa_resource_utilization: 90
 listener_load_balancer_proxy_protocol: true
 listener_load_balancer_cross_zone_load_balancing_enabled: true
 listener_replicas: 2
@@ -44,6 +49,11 @@ listener_resources_limits_memory: "700Mi"
 ## Worker
 worker_pdb_state: "present"
 worker_pdb_max_unavailable: 1
+worker_hpa_state: "present"
+worker_hpa_min_replicas: 2
+worker_hpa_max_replicas: 4
+worker_hpa_resource_name: "cpu"
+worker_hpa_resource_utilization: 90
 worker_replicas: 2
 worker_env_log_format: "json"
 worker_env_redis_async: "false"

--- a/roles/backend/defaults/main.yml
+++ b/roles/backend/defaults/main.yml
@@ -20,7 +20,7 @@ config_legacy_referrer_filters: "true"
 ## Listener
 listener_load_balancer_proxy_protocol: true
 listener_load_balancer_cross_zone_load_balancing_enabled: true
-listener_replicas: 1
+listener_replicas: 2
 listener_env_log_format: "json"
 listener_env_listener_workers: 16
 listener_env_redis_async: "false"
@@ -40,7 +40,7 @@ listener_resources_limits_cpu: "1"
 listener_resources_limits_memory: "700Mi"
 
 ## Worker
-worker_replicas: 1
+worker_replicas: 2
 worker_env_log_format: "json"
 worker_env_redis_async: "false"
 worker_liveness_probe_initial_delay_seconds: 10

--- a/roles/backend/tasks/main.yml
+++ b/roles/backend/tasks/main.yml
@@ -21,9 +21,29 @@
     definition: "{{ lookup('template', 'backend-error-monitoring-secretdefinition.yaml') }}"
   when: error_monitoring_enabled|bool == true
 
+- name: Convert listener.pdb.enabled boolean var into ansible listener_pdb_state state var for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    listener_pdb_state: "absent"
+  when: listener.pdb.enabled is defined and listener.pdb.enabled|bool == false
+
+- name: Manage backend-listener PodDisruptiveBudget for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ listener_pdb_state }}"
+    definition: "{{ lookup('template', 'backend-listener-pdb.yaml') }}"
+
 - name: Manage backend-listener Deployment for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     definition: "{{ lookup('template', 'backend-listener-deployment.yaml') }}"
+
+- name: Convert worker.pdb.enabled boolean var into ansible worker_pdb_state state var for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    worker_pdb_state: "absent"
+  when: worker.pdb.enabled is defined and worker.pdb.enabled|bool == false
+
+- name: Manage backend-worker PodDisruptiveBudget for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ worker_pdb_state }}"
+    definition: "{{ lookup('template', 'backend-worker-pdb.yaml') }}"
 
 - name: Manage backend-worker Deployment for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:

--- a/roles/backend/tasks/main.yml
+++ b/roles/backend/tasks/main.yml
@@ -31,6 +31,16 @@
     state: "{{ listener_pdb_state }}"
     definition: "{{ lookup('template', 'backend-listener-pdb.yaml') }}"
 
+- name: Convert listener.hpa.enabled boolean var into ansible listener_hpa_state state var for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    listener_hpa_state: "absent"
+  when: listener.hpa.enabled is defined and listener.hpa.enabled|bool == false
+
+- name: Manage backend-listener HoritzontalPodAutoscaler for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ listener_hpa_state }}"
+    definition: "{{ lookup('template', 'backend-listener-hpa.yaml') }}"
+
 - name: Manage backend-listener Deployment for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     definition: "{{ lookup('template', 'backend-listener-deployment.yaml') }}"
@@ -44,6 +54,16 @@
   k8s:
     state: "{{ worker_pdb_state }}"
     definition: "{{ lookup('template', 'backend-worker-pdb.yaml') }}"
+
+- name: Convert worker.hpa.enabled boolean var into ansible worker_hpa_state state var for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    worker_hpa_state: "absent"
+  when: worker.hpa.enabled is defined and worker.hpa.enabled|bool == false
+
+- name: Manage backend-worker HoritzontalPodAutoscaler for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ worker_hpa_state }}"
+    definition: "{{ lookup('template', 'backend-worker-hpa.yaml') }}"
 
 - name: Manage backend-worker Deployment for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:

--- a/roles/backend/tasks/main.yml
+++ b/roles/backend/tasks/main.yml
@@ -26,7 +26,7 @@
     listener_pdb_state: "absent"
   when: listener.pdb.enabled is defined and listener.pdb.enabled|bool == false
 
-- name: Manage backend-listener PodDisruptiveBudget for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
+- name: Manage backend-listener PodDisruptionBudget for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     state: "{{ listener_pdb_state }}"
     definition: "{{ lookup('template', 'backend-listener-pdb.yaml') }}"
@@ -50,7 +50,7 @@
     worker_pdb_state: "absent"
   when: worker.pdb.enabled is defined and worker.pdb.enabled|bool == false
 
-- name: Manage backend-worker PodDisruptiveBudget for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
+- name: Manage backend-worker PodDisruptionBudget for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     state: "{{ worker_pdb_state }}"
     definition: "{{ lookup('template', 'backend-worker-pdb.yaml') }}"

--- a/roles/backend/tasks/main.yml
+++ b/roles/backend/tasks/main.yml
@@ -77,6 +77,10 @@
   k8s:
     definition: "{{ lookup('template', 'backend-listener-service.yaml') }}"
 
+- name: Manage backend-listener-internal Service for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    definition: "{{ lookup('template', 'backend-listener-internal-service.yaml') }}"
+
 - name: Manage backend-listener PodMonitor for Backend {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     definition: "{{ lookup('template', 'backend-listener-podmonitor.yaml') }}"

--- a/roles/backend/templates/backend-listener-deployment.yaml
+++ b/roles/backend/templates/backend-listener-deployment.yaml
@@ -13,7 +13,9 @@ spec:
     rollingUpdate:
       maxSurge: 25%
       maxUnavailable: 25%
+{% if listener.hpa.enabled is defined and listener.hpa.enabled == false %}
   replicas: {{ listener.replicas | default(listener_replicas) }}
+{% endif %}
   selector:
     matchLabels:
       deployment: backend-listener

--- a/roles/backend/templates/backend-listener-deployment.yaml
+++ b/roles/backend/templates/backend-listener-deployment.yaml
@@ -165,5 +165,20 @@ spec:
               memory: "{{ listener.resources.limits.memory | default(listener_resources_limits_memory) }}"
               cpu: "{{ listener.resources.limits.cpu | default(listener_resources_limits_cpu) }}"
           imagePullPolicy: IfNotPresent
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  deployment: backend-listener
+          - weight: 99
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  deployment: backend-listener
       restartPolicy: Always
       terminationGracePeriodSeconds: 30

--- a/roles/backend/templates/backend-listener-hpa.yaml
+++ b/roles/backend/templates/backend-listener-hpa.yaml
@@ -1,0 +1,23 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: backend-listener
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: 3scale-api-management
+    threescale_component: backend
+    threescale_component_element: listener
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend-listener
+  minReplicas: {{ listener.hpa.min_replicas | default(listener_hpa_min_replicas) }}
+  maxReplicas: {{ listener.hpa.max_replicas | default(listener_hpa_max_replicas) }}
+  metrics:
+  - type: Resource
+    resource:
+      name: "{{ listener.hpa.resource_name | default(listener_hpa_resource_name) }}"
+      target:
+        type: Utilization
+        averageUtilization: {{ listener.hpa.resource_utilization | default(listener_hpa_resource_utilization) }}

--- a/roles/backend/templates/backend-listener-internal-service.yaml
+++ b/roles/backend/templates/backend-listener-internal-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-listener-internal
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: 3scale-api-management
+    threescale_component: backend
+    threescale_component_element: listener
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http-internal
+  selector:
+    deployment: backend-listener
+  type: ClusterIP

--- a/roles/backend/templates/backend-listener-pdb.yaml
+++ b/roles/backend/templates/backend-listener-pdb.yaml
@@ -8,7 +8,9 @@ metadata:
     threescale_component: backend
     threescale_component_element: listener
 spec:
+{% if listener.pdb.min_available is not defined %}
   maxUnavailable: {{ listener.pdb.max_unavailable | default(listener_pdb_max_unavailable) }}
+{% endif %}
 {% if listener.pdb.min_available is defined %}
   minAvailable: {{ listener.pdb.min_available }}
 {% endif %}

--- a/roles/backend/templates/backend-listener-pdb.yaml
+++ b/roles/backend/templates/backend-listener-pdb.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: backend-listener
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: 3scale-api-management
+    threescale_component: backend
+    threescale_component_element: listener
+spec:
+  maxUnavailable: {{ listener.pdb.max_unavailable | default(listener_pdb_max_unavailable) }}
+{% if listener.pdb.min_available is defined %}
+  minAvailable: {{ listener.pdb.min_available }}
+{% endif %}
+  selector:
+    matchLabels:
+      deployment: backend-listener

--- a/roles/backend/templates/backend-worker-deployment.yaml
+++ b/roles/backend/templates/backend-worker-deployment.yaml
@@ -13,7 +13,9 @@ spec:
     rollingUpdate:
       maxSurge: 25%
       maxUnavailable: 25%
+{% if worker.hpa.enabled is defined and worker.hpa.enabled == false %}
   replicas: {{ worker.replicas | default(worker_replicas) }}
+{% endif %}
   selector:
     matchLabels:
       deployment: backend-worker

--- a/roles/backend/templates/backend-worker-deployment.yaml
+++ b/roles/backend/templates/backend-worker-deployment.yaml
@@ -140,5 +140,20 @@ spec:
               memory: "{{ worker.resources.limits.memory | default(worker_resources_limits_memory) }}"
               cpu: "{{ worker.resources.limits.cpu | default(worker_resources_limits_cpu) }}"
           imagePullPolicy: IfNotPresent
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  deployment: backend-worker
+          - weight: 99
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  deployment: backend-worker
       restartPolicy: Always
       terminationGracePeriodSeconds: 30

--- a/roles/backend/templates/backend-worker-hpa.yaml
+++ b/roles/backend/templates/backend-worker-hpa.yaml
@@ -1,0 +1,23 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: backend-worker
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: 3scale-api-management
+    threescale_component: backend
+    threescale_component_element: worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend-worker
+  minReplicas: {{ worker.hpa.min_replicas | default(worker_hpa_min_replicas) }}
+  maxReplicas: {{ worker.hpa.max_replicas | default(worker_hpa_max_replicas) }}
+  metrics:
+  - type: Resource
+    resource:
+      name: "{{ worker.hpa.resource_name | default(worker_hpa_resource_name) }}"
+      target:
+        type: Utilization
+        averageUtilization: {{ worker.hpa.resource_utilization | default(worker_hpa_resource_utilization) }}

--- a/roles/backend/templates/backend-worker-pdb.yaml
+++ b/roles/backend/templates/backend-worker-pdb.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: backend-worker
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: 3scale-api-management
+    threescale_component: backend
+    threescale_component_element: worker
+spec:
+  maxUnavailable: {{ worker.pdb.max_unavailable | default(worker_pdb_max_unavailable) }}
+{% if worker.pdb.min_available is defined %}
+  minAvailable: {{ worker.pdb.min_available }}
+{% endif %}
+  selector:
+    matchLabels:
+      deployment: backend-worker

--- a/roles/backend/templates/backend-worker-pdb.yaml
+++ b/roles/backend/templates/backend-worker-pdb.yaml
@@ -8,7 +8,9 @@ metadata:
     threescale_component: backend
     threescale_component_element: worker
 spec:
+{% if worker.pdb.min_available is not defined %}
   maxUnavailable: {{ worker.pdb.max_unavailable | default(worker_pdb_max_unavailable) }}
+{% endif %}
 {% if worker.pdb.min_available is defined %}
   minAvailable: {{ worker.pdb.min_available }}
 {% endif %}


### PR DESCRIPTION
Closes https://github.com/3scale/saas-operator/issues/8
- Adds Makefile target to run operator locally
- Adds `PodDisruptionBudget` for backend-worker and backend-listener
  - Enabled by default (ansible state `present`)
  - Configured by default with `maxUnavailable:1`
  - CR field can be a `number` or a `percentage` (both cases tested and working)
  - If you want to use `minAvailable` instead of default `maxUnavailable`:
     - If you add it to the CR from the very beginning, it will be created PDB with `minAvailable` (ignoring default  `maxUnavailable`)
     - It PDB was already created with `maxUnavailable`, operator task managing PDB will fail, because ansible operator executed patch operation, and these 2 vars are mutually exclusive and cannot coexists on same PDB
    - It happens the same the other way around, if you have `minAvailable` and want to use  `maxUnavailable`
    - This race condition not being easy handled with limited ansible operator, has been documented at CR level, and it has been added a possible workaround either using CR fields or deleting object manually
  - There is a task converting CR boolean into internal ansible state "absent" in case you want to disable it (so we guarantee if you want to ensure it is not created, it wont be created, but in case it was already enabled and you disable it, then it will be deleted)
- Adds `HoritzontalPodAutoscaler` for backend-worker and backend-listener
  - Enabled by default (ansible state `present`)
  - Configured by default with:
    - `minReplicas:2`
    - `maxReplicas:4`
    - `resourceName:cpu` (only `cpu/memory` admitted at CRD level)
    - `resourceUtilization:90` (a percentage)
  - If set to `true`, then `replicas` CR field is ignored, not managed by Deployments
  - There is a task converting CR boolean into internal ansible state "absent" in case you want to disable it (so we guarantee if you want to ensure it is not created, it wont be created, but in case it was already enabled and you disable it, then it will be deleted)
- Adds `podAntiffinity` for backend-worker and backend-listener following best practices:
  - It is a soft `podAntiffinity` (using `Preferred` instead of `Required`)
  - With highest priority, it tries to use hosts where there is no pod with specific label
  - With lower priority, it tries to use hosts from different AWS AZs where there is no pod with specific label 
  - So finanly, il will try to balanced pods accross different AZs, and accross different hosts
- Update Backend CRD validation with new pdb/hpa fields
- Adds documentation for both PDB/HPA
- Add backend-listener-internal Service, because:
  - Current backend-listener Service is published via NLB with proxy-protocol enabled (both 80/443 ports)
  - Marin3r destination ports for Service 80/443 have configured proxy-protocol (so internal communication directly to the k8s Service, instead of public NLB, won't work, because NLB is the one adding proxy-protocol)
  - Backend-listener needs to be accessed internally by ,at least, System component, so we require an extra Service whose marin3r port won't have proxy-protocol enabled


## PodAntiffinity tests
Regarding `podAntiffinity`, I have done several testing to ensure it is working as expected.

So this is the worker nodes, 2 per AZ:
```
ip-10-65-0-91.ec2.internal    Ready     worker    82d       v1.16.2 --> us-east-1a
ip-10-65-1-200.ec2.internal   Ready     worker    132d      v1.16.2 --> us-east-1a
ip-10-65-6-169.ec2.internal   Ready     worker    132d      v1.16.2 --> us-east-1b
ip-10-65-7-70.ec2.internal    Ready     worker    82d       v1.16.2 --> us-east-1b
ip-10-65-9-40.ec2.internal    Ready     worker    132d      v1.16.2 --> us-east-1c
ip-10-65-11-2.ec2.internal    Ready     worker    82d       v1.16.2 --> us-east-1c
```

- I have increased, one by one, the number of replicas per deployment, and it has always ensured the expected distribution accross AZs and nodes
- Even when I decreased from 6 to 3 replicas, it still balanced one pod per AZ

### Evolution history of AZs used by each deployment depending on number of replicas

- Listener:
  - Initial 2 replicas: a/b
  - UP to 3 replicas: a/b/c
  - UP to 4 replicas: a/b/c/b
  - UP to 5 replicas: a/b/c/b/a
  - UP to 6 replicas: a/b/c/b/a/c
  - DOWN to 3 replicas: a/b/c

- Worker:
  - Initial 2 replicas: c/b
  - UP to 3 replicas: c/b/a
  - UP to 4 replicas: c/b/a/b
  - UP to 5 replicas: c/b/a/b/c
  - UP to 6 replicas: c/b/a/b/c/a
  - DOWN to 3 replicas: a/b/c

