### PR TITLE
Feature/Update marin3r annotations config on EchoAPI controller

### DIFF
--- a/deploy/crds/saas.3scale.net_echoapis_crd.yaml
+++ b/deploy/crds/saas.3scale.net_echoapis_crd.yaml
@@ -35,7 +35,6 @@ spec:
           required:
           - externalDnsHostname
           - marin3r
-          - deploymentAnnotations
           properties:
             image:
               type: object
@@ -124,11 +123,11 @@ spec:
                 enabled:
                   type: boolean
                   description:  Enable (true) or disable (false) marin3r
-            deploymentAnnotations:
-              additionalProperties:
-                type: string
-              description: Map of deployment annotations
-              type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Map of deployment annotations
+                  type: object
             loadBalancer:
               type: object
               properties:

--- a/deploy/crds/saas.3scale.net_v1alpha1_echoapi_cr.yaml
+++ b/deploy/crds/saas.3scale.net_v1alpha1_echoapi_cr.yaml
@@ -9,6 +9,6 @@ spec:
   externalDnsHostname: echo-api.example.3scale.net
   marin3r:
     enabled: true
-  deploymentAnnotations:
-    marin3r.3scale.net/node-id: echo-api
-    marin3r.3scale.net/ports: echo-api-http:38080,echo-api-https:38443,envoy-metrics:9901
+    annotations:
+      marin3r.3scale.net/node-id: echo-api
+      marin3r.3scale.net/ports: echo-api-http:38080,echo-api-https:38443,envoy-metrics:9901

--- a/docs/echoapi-crd-reference.md
+++ b/docs/echoapi-crd-reference.md
@@ -14,9 +14,9 @@ spec:
   externalDnsHostname: echo-api.example.3scale.net
   marin3r:
     enabled: true
-  deploymentAnnotations:
-    marin3r.3scale.net/node-id: echo-api
-    marin3r.3scale.net/ports: echo-api-http:38080,echo-api-https:38443,envoy-metrics:9901
+    annotations:
+      marin3r.3scale.net/node-id: echo-api
+      marin3r.3scale.net/ports: echo-api-http:38080,echo-api-https:38443,envoy-metrics:9901
 ```
 
 ## Full CR Example
@@ -56,9 +56,9 @@ spec:
   externalDnsHostname: echo-api.example.3scale.net
   marin3r:
     enabled: true
-  deploymentAnnotations:
-    marin3r.3scale.net/node-id: echo-api
-    marin3r.3scale.net/ports: echo-api-http:38080,echo-api-https:38443,envoy-metrics:9901
+    annotations:
+      marin3r.3scale.net/node-id: echo-api
+      marin3r.3scale.net/ports: echo-api-http:38080,echo-api-https:38443,envoy-metrics:9901
   loadBalancer:
     proxyProtocol: true
     crossZoneLoadBalancingEnabled: true
@@ -88,6 +88,6 @@ spec:
 | `readinessProbe.failureThreshold` | `int` | No | `3` | Override readiness failure threshold |
 | `externalDnsHostname` | `string` | Yes | - | DNS hostnames to manage on AWS Route53 by external-dns |
 | `marin3r.enabled` | `boolean` | Yes | - | Enable (`true`) or disable (`false`) marin3r |
-| `deploymentAnnotations.{}` | `map` | Yes | - | Map of deployment annotations |
+| `marin3r.annotations.{}` | `map` | No | - | Map of marin3r annotations |
 | `loadBalancer.proxyProtocol` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) proxy protocol with aws-nlb-helper-operator |
 | `loadBalancer.crossZoneLoadBalancingEnabled` | `bool` | No | `true` | Enable (`true`) or disable (`false`) cross zone load balancing |

--- a/roles/echoapi/tasks/main.yml
+++ b/roles/echoapi/tasks/main.yml
@@ -1,10 +1,5 @@
 ---
 
-
-- name: Fix deploymentAnnotations map var that may contain originally hyphens but ansible has converted to underscore
-  set_fact:
-    deployment_annotations_clean: "{{ deployment_annotations | regex_replace ('_','-') }}"
-
 - name: Manage echo-api Deployment for EchoAPI {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     definition: "{{ lookup('template', 'echo-api-deployment.yaml') }}"

--- a/roles/echoapi/templates/echo-api-deployment.yaml
+++ b/roles/echoapi/templates/echo-api-deployment.yaml
@@ -19,10 +19,19 @@ spec:
         app: echo-api
         threescale_component: echo-api
         threescale_component_element: echo-api
-{% if marin3r.enabled is defined and marin3r.enabled == true %}
+{% if marin3r.enabled == true %}
         marin3r.3scale.net/status: "enabled"
+{% if marin3r.annotations is defined %}
+      annotations:
+{# This is a hack to reverse the ansible operator -/_ convertion of dict keys #}
+{%- for key in marin3r.annotations -%}
+{% set key_replace = key | replace('_','-') %}
+        {{ key_replace }}: {{ marin3r.annotations[key] | safe }}
+{% endfor %}
 {% endif %}
-      annotations: {{ deployment_annotations_clean }}
+{% else %}
+        marin3r.3scale.net/status: "disabled"
+{% endif %}
     spec:
 {% if image.pull_secret_name is defined %}
       imagePullSecrets:

--- a/roles/echoapi/templates/echo-api-podmonitor.yaml
+++ b/roles/echoapi/templates/echo-api-podmonitor.yaml
@@ -9,7 +9,7 @@ metadata:
     threescale_component_element: echo-api
 spec:
   podMetricsEndpoints:
-    - interval: 30s
+    - interval: 60s
       path: /stats/prometheus
       port: envoy-metrics
       relabelings:


### PR DESCRIPTION
Closes https://github.com/3scale/saas-operator/issues/30
- Replaces marin3r deployment annotations managed by  `deploymentAnnotations` map with `marin3r.annotations` map
- Update examples, docs, and added CRD validation for new fields
- Updated PodMonitor interval for envoy-metrics to 60s (it is more than enough, envoy has lots of metrics, and increasing frequency we reduce possibility to fill-up prometheus volume)