### PR TITLE
Add PDB/HPA rbac permissions to operator role

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -89,6 +89,32 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  - poddisruptionbudgets/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  - horizontalpodautoscalers/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resourceNames:
   - threescale-saas-operator


### PR DESCRIPTION
On https://github.com/3scale/saas-operator/pull/29 it has been added PDB/HPA management to Backend controller.

I used the operator development mode with my admin credentials and everythign worked as expected while testing new Backend features.

However, when deploying it into staging environment, operator fail to manage PDB and HPA resources because it doesn't have rbac permission.

This PR fixes operator role with required rbac configuration.