### PR TITLE
Feature/Add HA to Apicast controller

### DIFF
--- a/deploy/crds/saas.3scale.net_apicasts_crd.yaml
+++ b/deploy/crds/saas.3scale.net_apicasts_crd.yaml
@@ -63,6 +63,18 @@ spec:
                     pullSecretName:
                       type: string
                       description: Quay pull secret for private repository
+                pdb:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) PodDisruptionBudget
+                    maxUnavailable:
+                      type: string
+                      description: Maximum number of unavailable pods (number or percentage of pods)
+                    minAvailable:
+                      type: string
+                      description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
                 replicas:
                   type: integer
                   description: Number of replicas
@@ -214,6 +226,18 @@ spec:
                     pullSecretName:
                       type: string
                       description: Quay pull secret for private repository
+                pdb:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) PodDisruptionBudget
+                    maxUnavailable:
+                      type: string
+                      description: Maximum number of unavailable pods (number or percentage of pods)
+                    minAvailable:
+                      type: string
+                      description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
                 replicas:
                   type: integer
                   description: Number of replicas

--- a/deploy/crds/saas.3scale.net_apicasts_crd.yaml
+++ b/deploy/crds/saas.3scale.net_apicasts_crd.yaml
@@ -71,9 +71,11 @@ spec:
                       description: Enable (true) or disable (false) PodDisruptionBudget
                     maxUnavailable:
                       type: string
+                      pattern: "^[0-9]+%?$"
                       description: Maximum number of unavailable pods (number or percentage of pods)
                     minAvailable:
                       type: string
+                      pattern: "^[0-9]+%?$"
                       description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
                 hpa:
                   type: object
@@ -255,9 +257,11 @@ spec:
                       description: Enable (true) or disable (false) PodDisruptionBudget
                     maxUnavailable:
                       type: string
+                      pattern: "^[0-9]+%?$"
                       description: Maximum number of unavailable pods (number or percentage of pods)
                     minAvailable:
                       type: string
+                      pattern: "^[0-9]+%?$"
                       description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
                 hpa:
                   type: object

--- a/deploy/crds/saas.3scale.net_apicasts_crd.yaml
+++ b/deploy/crds/saas.3scale.net_apicasts_crd.yaml
@@ -75,9 +75,30 @@ spec:
                     minAvailable:
                       type: string
                       description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
+                hpa:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) HoritzontalPodAutoscaler
+                    minReplicas:
+                      type: integer
+                      description: Minimum number of replicas
+                    maxReplicas:
+                      type: integer
+                      description: Maximum number of replicas
+                    resourceName:
+                      type: string
+                      description: Resource used for autoscale (cpu/memory)
+                      enum:
+                      - cpu
+                      - memory
+                    resourceUtilization:
+                      type: integer
+                      description: Percentage usage of the resource used for autoscale
                 replicas:
                   type: integer
-                  description: Number of replicas
+                  description: Number of replicas (ignored if hpa is enabled)
                 env:
                   type: object
                   description: Environment variables
@@ -238,9 +259,30 @@ spec:
                     minAvailable:
                       type: string
                       description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
+                hpa:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) HoritzontalPodAutoscaler
+                    minReplicas:
+                      type: integer
+                      description: Minimum number of replicas
+                    maxReplicas:
+                      type: integer
+                      description: Maximum number of replicas
+                    resourceName:
+                      type: string
+                      description: Resource used for autoscale (cpu/memory)
+                      enum:
+                      - cpu
+                      - memory
+                    resourceUtilization:
+                      type: integer
+                      description: Percentage usage of the resource used for autoscale
                 replicas:
                   type: integer
-                  description: Number of replicas
+                  description: Number of replicas (ignored if hpa is enabled)
                 env:
                   type: object
                   description: Environment variables

--- a/docs/apicast-crd-reference.md
+++ b/docs/apicast-crd-reference.md
@@ -55,7 +55,12 @@ spec:
     pdb:
       enabled: true
       maxUnavailable: "1"
-    replicas: 1
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 4
+      resourceName: cpu
+      resourceUtilization: 90
     env:
       apicastConfigurationCache: "30"
       threescalePortalEndpoint: "http://mapping-service/config"
@@ -95,7 +100,12 @@ spec:
     pdb:
       enabled: true
       minAvailable: "80%"
-    replicas: 1
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 4
+      resourceName: cpu
+      resourceUtilization: 90
     env:
       apicastConfigurationCache: "300"
       threescalePortalEndpoint: "http://mapping-service/config"
@@ -152,7 +162,12 @@ spec:
 |                       `staging.pdb.enabled`                       | `boolean` |      No      |                `true`                 |                 Enable (`true`) or disable (`false`) PodDisruptionBudget                  |
 |                   `staging.pdb.maxUnavailable`                    | `string`  |      No      |                  `1`                  |             Maximum number of unavailable pods (number or percentage of pods)             |
 |                    `staging.pdb.minAvailable`                     | `string`  |      No      |                   -                   | Minimum number of available pods (number or percentage of pods), overrides maxUnavailable |
-|                        `staging.replicas`                         |   `int`   |      No      |                  `2`                  |                                    Number of replicas                                     |
+|                       `staging.hpa.enabled`                       | `boolean` |      No      |                `true`                 |               Enable (`true`) or disable (`false`) HoritzontalPodAutoscaler               |
+|                     `staging.hpa.minReplicas`                     |   `int`   |      No      |                  `2`                  |                                Minimum number of replicas                                 |
+|                     `staging.hpa.maxReplicas`                     |   `int`   |      No      |                  `4`                  |                                Maximum number of replicas                                 |
+|                    `staging.hpa.resourceName`                     | `string`  |      No      |                 `cpu`                 |                         Resource used for autoscale (cpu/memory)                          |
+|                 `staging.hpa.resourceUtilization`                 |   `int`   |      No      |                 `90`                  |                    Percentage usage of the resource used for autoscale                    |
+|                        `staging.replicas`                         |   `int`   |      No      |                  `2`                  |                      Number of replicas (ignored if hpa is enabled)                       |
 |              `staging.env.apicastConfigurationCache`              | `string`  |     Yes      |                   -                   |                             Apicast configurations cache TTL                              |
 |              `staging.env.threescalePortalEndpoint`               | `string`  |     Yes      |                   -                   |                        Endpoint to request proxy configurations to                        |
 |                   `staging.env.apicastLogLevel`                   | `string`  |      No      |                `warn`                 |                                    Openresty log level                                    |
@@ -188,7 +203,12 @@ spec:
 |                     `production.pdb.enabled`                      | `boolean` |      No      |                `true`                 |                 Enable (`true`) or disable (`false`) PodDisruptionBudget                  |
 |                  `production.pdb.maxUnavailable`                  | `string`  |      No      |                  `1`                  |             Maximum number of unavailable pods (number or percentage of pods)             |
 |                   `production.pdb.minAvailable`                   | `string`  |      No      |                   -                   | Minimum number of available pods (number or percentage of pods), overrides maxUnavailable |
-|                       `production.replicas`                       |   `int`   |      No      |                  `2`                  |                                    Number of replicas                                     |
+|                     `production.hpa.enabled`                      | `boolean` |      No      |                `true`                 |               Enable (`true`) or disable (`false`) HoritzontalPodAutoscaler               |
+|                   `production.hpa.minReplicas`                    |   `int`   |      No      |                  `2`                  |                                Minimum number of replicas                                 |
+|                   `production.hpa.maxReplicas`                    |   `int`   |      No      |                  `4`                  |                                Maximum number of replicas                                 |
+|                   `production.hpa.resourceName`                   | `string`  |      No      |                 `cpu`                 |                         Resource used for autoscale (cpu/memory)                          |
+|               `production.hpa.resourceUtilization`                |   `int`   |      No      |                 `90`                  |                    Percentage usage of the resource used for autoscale                    |
+|                       `production.replicas`                       |   `int`   |      No      |                  `2`                  |                      Number of replicas (ignored if hpa is enabled)                       |
 |            `production.env.apicastConfigurationCache`             | `string`  |     Yes      |                   -                   |                             Apicast configurations cache TTL                              |
 |             `production.env.threescalePortalEndpoint`             | `string`  |     Yes      |                   -                   |                        Endpoint to request proxy configurations to                        |
 |                 `production.env.apicastLogLevel`                  | `string`  |      No      |                `warn`                 |                                    Openresty log level                                    |

--- a/docs/apicast-crd-reference.md
+++ b/docs/apicast-crd-reference.md
@@ -143,7 +143,7 @@ spec:
 |                       `staging.image.name`                        | `string`  |      No      | `quay.io/3scale/apicast-cloud-hosted` |                      Image name (docker repository)                      |
 |                        `staging.image.tag`                        | `string`  |     Yes      |                   -                   |                                Image tag                                 |
 |                  `staging.image.pullSecretName`                   | `string`  |      No      |                   -                   |                 Quay pull secret for private repository                  |
-|                        `staging.replicas`                         |   `int`   |      No      |                  `1`                  |                            Number of replicas                            |
+|                        `staging.replicas`                         |   `int`   |      No      |                  `2`                  |                            Number of replicas                            |
 |              `staging.env.apicastConfigurationCache`              | `string`  |     Yes      |                   -                   |                     Apicast configurations cache TTL                     |
 |              `staging.env.threescalePortalEndpoint`               | `string`  |     Yes      |                   -                   |               Endpoint to request proxy configurations to                |
 |                   `staging.env.apicastLogLevel`                   | `string`  |      No      |                `warn`                 |                           Openresty log level                            |
@@ -176,7 +176,7 @@ spec:
 |                      `production.image.name`                      | `string`  |      No      | `quay.io/3scale/apicast-cloud-hosted` |                      Image name (docker repository)                      |
 |                      `production.image.tag`                       | `string`  |     Yes      |                   -                   |                                Image tag                                 |
 |                 `production.image.pullSecretName`                 | `string`  |      No      |                   -                   |                 Quay pull secret for private repository                  |
-|                       `production.replicas`                       |   `int`   |      No      |                  `1`                  |                            Number of replicas                            |
+|                       `production.replicas`                       |   `int`   |      No      |                  `2`                  |                            Number of replicas                            |
 |            `production.env.apicastConfigurationCache`             | `string`  |     Yes      |                   -                   |                     Apicast configurations cache TTL                     |
 |             `production.env.threescalePortalEndpoint`             | `string`  |     Yes      |                   -                   |               Endpoint to request proxy configurations to                |
 |                 `production.env.apicastLogLevel`                  | `string`  |      No      |                `warn`                 |                           Openresty log level                            |

--- a/docs/apicast-crd-reference.md
+++ b/docs/apicast-crd-reference.md
@@ -52,6 +52,9 @@ spec:
       name: quay.io/3scale/apicast-cloud-hosted
       tag: apicast-v3.8.0-r3
       pullSecretName: quay-pull-secret
+    pdb:
+      enabled: true
+      maxUnavailable: "1"
     replicas: 1
     env:
       apicastConfigurationCache: "30"
@@ -89,6 +92,9 @@ spec:
       name: quay.io/3scale/apicast-cloud-hosted
       tag: apicast-v3.8.0-r3
       pullSecretName: quay-pull-secret
+    pdb:
+      enabled: true
+      minAvailable: "80%"
     replicas: 1
     env:
       apicastConfigurationCache: "300"
@@ -138,73 +144,79 @@ spec:
 
 ## CR Spec
 
-|                             **Field**                             | **Type**  | **Required** |           **Default value**           |                             **Description**                              |
-| :---------------------------------------------------------------: | :-------: | :----------: | :-----------------------------------: | :----------------------------------------------------------------------: |
-|                       `staging.image.name`                        | `string`  |      No      | `quay.io/3scale/apicast-cloud-hosted` |                      Image name (docker repository)                      |
-|                        `staging.image.tag`                        | `string`  |     Yes      |                   -                   |                                Image tag                                 |
-|                  `staging.image.pullSecretName`                   | `string`  |      No      |                   -                   |                 Quay pull secret for private repository                  |
-|                        `staging.replicas`                         |   `int`   |      No      |                  `2`                  |                            Number of replicas                            |
-|              `staging.env.apicastConfigurationCache`              | `string`  |     Yes      |                   -                   |                     Apicast configurations cache TTL                     |
-|              `staging.env.threescalePortalEndpoint`               | `string`  |     Yes      |                   -                   |               Endpoint to request proxy configurations to                |
-|                   `staging.env.apicastLogLevel`                   | `string`  |      No      |                `warn`                 |                           Openresty log level                            |
-|                 `staging.env.apicastOIDCLogLevel`                 | `string`  |      No      |               `notice`                |                   OpenID Connect integration log level                   |
-|                     `staging.marin3r.enabled`                     | `boolean` |     Yes      |                   -                   |               Enable (`true`) or disable (`false`) marin3r               |
-|                 `staging.marin3r.annotations.{}`                  |   `map`   |      No      |                   -                   |                        Map of marin3r annotations                        |
-|                 `staging.resources.requests.cpu`                  | `string`  |      No      |                `500m`                 |                          Override CPU requests                           |
-|                `staging.resources.requests.memory`                | `string`  |      No      |                `64Mi`                 |                         Override Memory requests                         |
-|                  `staging.resources.limits.cpu`                   | `string`  |      No      |                  `1`                  |                           Override CPU limits                            |
-|                 `staging.resources.limits.memory`                 | `string`  |      No      |                `128Mi`                |                          Override Memory limits                          |
-|            `staging.livenessProbe.initialDelaySeconds`            |   `int`   |      No      |                  `5`                  |                Override liveness initial delay (seconds)                 |
-|              `staging.livenessProbe.timeoutSeconds`               |   `int`   |      No      |                  `5`                  |                   Override liveness timeout (seconds)                    |
-|               `staging.livenessProbe.periodSeconds`               |   `int`   |      No      |                 `10`                  |                    Override liveness period (seconds)                    |
-|             `staging.livenessProbe.successThreshold`              |   `int`   |      No      |                  `1`                  |                   Override liveness success threshold                    |
-|             `staging.livenessProbe.failureThreshold`              |   `int`   |      No      |                  `3`                  |                   Override liveness failure threshold                    |
-|           `staging.readinessProbe.initialDelaySeconds`            |   `int`   |      No      |                  `5`                  |                Override readiness initial delay (seconds)                |
-|              `staging.readinessProbe.timeoutSeconds`              |   `int`   |      No      |                  `5`                  |                   Override readiness timeout (seconds)                   |
-|              `staging.readinessProbe.periodSeconds`               |   `int`   |      No      |                 `30`                  |                   Override readiness period (seconds)                    |
-|             `staging.readinessProbe.successThreshold`             |   `int`   |      No      |                  `1`                  |                   Override readiness success threshold                   |
-|             `staging.readinessProbe.failureThreshold`             |   `int`   |      No      |                  `3`                  |                   Override readiness failure threshold                   |
-|                   `staging.externalDnsHostname`                   | `string`  |     Yes      |                   -                   |          DNS hostnames to manage on AWS Route53 by external-dns          |
-|               `staging.loadBalancer.proxyProtocol`                | `string`  |      No      |                  `*`                  | Proxy protocol enabled (k8s aws provider only accepts `*` by the moment) |
-|       `staging.loadBalancer.crossZoneLoadBalancingEnabled`        |  `bool`   |      No      |                `true`                 |      Enable (`true`) or disable (`false`) cross zone load balancing      |
-|         `staging.loadBalancer.connectionDrainingEnabled`          |  `bool`   |      No      |                `true`                 |         Enable (`true`) or disable (`false`) connection draining         |
-|         `staging.loadBalancer.connectionDrainingTimeout`          |   `int`   |      No      |                 `60`                  |                  Connection draining timeout (seconds)                   |
-|   `staging.loadBalancer.connectionHealthcheckHealthyThreshold`    |   `int`   |      No      |                  `2`                  |                 Connection healthcheck healthy threshold                 |
-|  `staging.loadBalancer.connectionHealthcheckUnhealthyThreshold`   |   `int`   |      No      |                  `2`                  |                Connection healthcheck unhealthy threshold                |
-|       `staging.loadBalancer.connectionHealthcheckInterval`        |   `int`   |      No      |                  `5`                  |                Connection healthcheck interval (seconds)                 |
-|        `staging.loadBalancer.connectionHealthcheckTimeout`        |   `int`   |      No      |                  `3`                  |                 Connection healthcheck timeout (seconds)                 |
-|                      `production.image.name`                      | `string`  |      No      | `quay.io/3scale/apicast-cloud-hosted` |                      Image name (docker repository)                      |
-|                      `production.image.tag`                       | `string`  |     Yes      |                   -                   |                                Image tag                                 |
-|                 `production.image.pullSecretName`                 | `string`  |      No      |                   -                   |                 Quay pull secret for private repository                  |
-|                       `production.replicas`                       |   `int`   |      No      |                  `2`                  |                            Number of replicas                            |
-|            `production.env.apicastConfigurationCache`             | `string`  |     Yes      |                   -                   |                     Apicast configurations cache TTL                     |
-|             `production.env.threescalePortalEndpoint`             | `string`  |     Yes      |                   -                   |               Endpoint to request proxy configurations to                |
-|                 `production.env.apicastLogLevel`                  | `string`  |      No      |                `warn`                 |                           Openresty log level                            |
-|               `production.env.apicastOIDCLogLevel`                | `string`  |      No      |               `notice`                |                   OpenID Connect integration log level                   |
-|                   `production.marin3r.enabled`                    | `boolean` |     Yes      |                   -                   |               Enable (`true`) or disable (`false`) marin3r               |
-|                `production.marin3r.annotations.{}`                |   `map`   |      No      |                   -                   |                        Map of marin3r annotations                        |
-|                `production.resources.requests.cpu`                | `string`  |      No      |                `500m`                 |                          Override CPU requests                           |
-|              `production.resources.requests.memory`               | `string`  |      No      |                `64Mi`                 |                         Override Memory requests                         |
-|                 `production.resources.limits.cpu`                 | `string`  |      No      |                  `1`                  |                           Override CPU limits                            |
-|               `production.resources.limits.memory`                | `string`  |      No      |                `128Mi`                |                          Override Memory limits                          |
-|          `production.livenessProbe.initialDelaySeconds`           |   `int`   |      No      |                  `5`                  |                Override liveness initial delay (seconds)                 |
-|             `production.livenessProbe.timeoutSeconds`             |   `int`   |      No      |                  `5`                  |                   Override liveness timeout (seconds)                    |
-|             `production.livenessProbe.periodSeconds`              |   `int`   |      No      |                 `10`                  |                    Override liveness period (seconds)                    |
-|            `production.livenessProbe.successThreshold`            |   `int`   |      No      |                  `1`                  |                   Override liveness success threshold                    |
-|            `production.livenessProbe.failureThreshold`            |   `int`   |      No      |                  `3`                  |                   Override liveness failure threshold                    |
-|          `production.readinessProbe.initialDelaySeconds`          |   `int`   |      No      |                  `5`                  |                Override readiness initial delay (seconds)                |
-|            `production.readinessProbe.timeoutSeconds`             |   `int`   |      No      |                  `5`                  |                   Override readiness timeout (seconds)                   |
-|             `production.readinessProbe.periodSeconds`             |   `int`   |      No      |                 `30`                  |                   Override readiness period (seconds)                    |
-|           `production.readinessProbe.successThreshold`            |   `int`   |      No      |                  `1`                  |                   Override readiness success threshold                   |
-|           `production.readinessProbe.failureThreshold`            |   `int`   |      No      |                  `3`                  |                   Override readiness failure threshold                   |
-|                 `production.externalDnsHostname`                  | `string`  |     Yes      |                   -                   |          DNS hostnames to manage on AWS Route53 by external-dns          |
-|              `production.loadBalancer.proxyProtocol`              | `string`  |      No      |                  `*`                  | Proxy protocol enabled (k8s aws provider only accepts `*` by the moment) |
-|      `production.loadBalancer.crossZoneLoadBalancingEnabled`      |  `bool`   |      No      |                `true`                 |      Enable (`true`) or disable (`false`) cross zone load balancing      |
-|        `production.loadBalancer.connectionDrainingEnabled`        |  `bool`   |      No      |                `true`                 |         Enable (`true`) or disable (`false`) connection draining         |
-|        `production.loadBalancer.connectionDrainingTimeout`        |   `int`   |      No      |                 `60`                  |                  Connection draining timeout (seconds)                   |
-|  `production.loadBalancer.connectionHealthcheckHealthyThreshold`  |   `int`   |      No      |                  `2`                  |                 Connection healthcheck healthy threshold                 |
-| `production.loadBalancer.connectionHealthcheckUnhealthyThreshold` |   `int`   |      No      |                  `2`                  |                Connection healthcheck unhealthy threshold                |
-|      `production.loadBalancer.connectionHealthcheckInterval`      |   `int`   |      No      |                  `5`                  |                Connection healthcheck interval (seconds)                 |
-|      `production.loadBalancer.connectionHealthcheckTimeout`       |   `int`   |      No      |                  `3`                  |                 Connection healthcheck timeout (seconds)                 |
-|                   `grafanaDashboard.label.key`                    | `string`  |      No      |           `monitoring-key`            |       Label `key` used by grafana-operator for dashboard discovery       |
-|                  `grafanaDashboard.label.value`                   | `string`  |      No      |             `middleware`              |      Label `value` used by grafana-operator for dashboard discovery      |
+|                             **Field**                             | **Type**  | **Required** |           **Default value**           |                                      **Description**                                      |
+| :---------------------------------------------------------------: | :-------: | :----------: | :-----------------------------------: | :---------------------------------------------------------------------------------------: |
+|                       `staging.image.name`                        | `string`  |      No      | `quay.io/3scale/apicast-cloud-hosted` |                              Image name (docker repository)                               |
+|                        `staging.image.tag`                        | `string`  |     Yes      |                   -                   |                                         Image tag                                         |
+|                  `staging.image.pullSecretName`                   | `string`  |      No      |                   -                   |                          Quay pull secret for private repository                          |
+|                       `staging.pdb.enabled`                       | `boolean` |      No      |                `true`                 |                 Enable (`true`) or disable (`false`) PodDisruptionBudget                  |
+|                   `staging.pdb.maxUnavailable`                    | `string`  |      No      |                  `1`                  |             Maximum number of unavailable pods (number or percentage of pods)             |
+|                    `staging.pdb.minAvailable`                     | `string`  |      No      |                   -                   | Minimum number of available pods (number or percentage of pods), overrides maxUnavailable |
+|                        `staging.replicas`                         |   `int`   |      No      |                  `2`                  |                                    Number of replicas                                     |
+|              `staging.env.apicastConfigurationCache`              | `string`  |     Yes      |                   -                   |                             Apicast configurations cache TTL                              |
+|              `staging.env.threescalePortalEndpoint`               | `string`  |     Yes      |                   -                   |                        Endpoint to request proxy configurations to                        |
+|                   `staging.env.apicastLogLevel`                   | `string`  |      No      |                `warn`                 |                                    Openresty log level                                    |
+|                 `staging.env.apicastOIDCLogLevel`                 | `string`  |      No      |               `notice`                |                           OpenID Connect integration log level                            |
+|                     `staging.marin3r.enabled`                     | `boolean` |     Yes      |                   -                   |                       Enable (`true`) or disable (`false`) marin3r                        |
+|                 `staging.marin3r.annotations.{}`                  |   `map`   |      No      |                   -                   |                                Map of marin3r annotations                                 |
+|                 `staging.resources.requests.cpu`                  | `string`  |      No      |                `500m`                 |                                   Override CPU requests                                   |
+|                `staging.resources.requests.memory`                | `string`  |      No      |                `64Mi`                 |                                 Override Memory requests                                  |
+|                  `staging.resources.limits.cpu`                   | `string`  |      No      |                  `1`                  |                                    Override CPU limits                                    |
+|                 `staging.resources.limits.memory`                 | `string`  |      No      |                `128Mi`                |                                  Override Memory limits                                   |
+|            `staging.livenessProbe.initialDelaySeconds`            |   `int`   |      No      |                  `5`                  |                         Override liveness initial delay (seconds)                         |
+|              `staging.livenessProbe.timeoutSeconds`               |   `int`   |      No      |                  `5`                  |                            Override liveness timeout (seconds)                            |
+|               `staging.livenessProbe.periodSeconds`               |   `int`   |      No      |                 `10`                  |                            Override liveness period (seconds)                             |
+|             `staging.livenessProbe.successThreshold`              |   `int`   |      No      |                  `1`                  |                            Override liveness success threshold                            |
+|             `staging.livenessProbe.failureThreshold`              |   `int`   |      No      |                  `3`                  |                            Override liveness failure threshold                            |
+|           `staging.readinessProbe.initialDelaySeconds`            |   `int`   |      No      |                  `5`                  |                        Override readiness initial delay (seconds)                         |
+|              `staging.readinessProbe.timeoutSeconds`              |   `int`   |      No      |                  `5`                  |                           Override readiness timeout (seconds)                            |
+|              `staging.readinessProbe.periodSeconds`               |   `int`   |      No      |                 `30`                  |                            Override readiness period (seconds)                            |
+|             `staging.readinessProbe.successThreshold`             |   `int`   |      No      |                  `1`                  |                           Override readiness success threshold                            |
+|             `staging.readinessProbe.failureThreshold`             |   `int`   |      No      |                  `3`                  |                           Override readiness failure threshold                            |
+|                   `staging.externalDnsHostname`                   | `string`  |     Yes      |                   -                   |                  DNS hostnames to manage on AWS Route53 by external-dns                   |
+|               `staging.loadBalancer.proxyProtocol`                | `string`  |      No      |                  `*`                  |         Proxy protocol enabled (k8s aws provider only accepts `*` by the moment)          |
+|       `staging.loadBalancer.crossZoneLoadBalancingEnabled`        |  `bool`   |      No      |                `true`                 |              Enable (`true`) or disable (`false`) cross zone load balancing               |
+|         `staging.loadBalancer.connectionDrainingEnabled`          |  `bool`   |      No      |                `true`                 |                 Enable (`true`) or disable (`false`) connection draining                  |
+|         `staging.loadBalancer.connectionDrainingTimeout`          |   `int`   |      No      |                 `60`                  |                           Connection draining timeout (seconds)                           |
+|   `staging.loadBalancer.connectionHealthcheckHealthyThreshold`    |   `int`   |      No      |                  `2`                  |                         Connection healthcheck healthy threshold                          |
+|  `staging.loadBalancer.connectionHealthcheckUnhealthyThreshold`   |   `int`   |      No      |                  `2`                  |                        Connection healthcheck unhealthy threshold                         |
+|       `staging.loadBalancer.connectionHealthcheckInterval`        |   `int`   |      No      |                  `5`                  |                         Connection healthcheck interval (seconds)                         |
+|        `staging.loadBalancer.connectionHealthcheckTimeout`        |   `int`   |      No      |                  `3`                  |                         Connection healthcheck timeout (seconds)                          |
+|                      `production.image.name`                      | `string`  |      No      | `quay.io/3scale/apicast-cloud-hosted` |                              Image name (docker repository)                               |
+|                      `production.image.tag`                       | `string`  |     Yes      |                   -                   |                                         Image tag                                         |
+|                 `production.image.pullSecretName`                 | `string`  |      No      |                   -                   |                          Quay pull secret for private repository                          |
+|                     `production.pdb.enabled`                      | `boolean` |      No      |                `true`                 |                 Enable (`true`) or disable (`false`) PodDisruptionBudget                  |
+|                  `production.pdb.maxUnavailable`                  | `string`  |      No      |                  `1`                  |             Maximum number of unavailable pods (number or percentage of pods)             |
+|                   `production.pdb.minAvailable`                   | `string`  |      No      |                   -                   | Minimum number of available pods (number or percentage of pods), overrides maxUnavailable |
+|                       `production.replicas`                       |   `int`   |      No      |                  `2`                  |                                    Number of replicas                                     |
+|            `production.env.apicastConfigurationCache`             | `string`  |     Yes      |                   -                   |                             Apicast configurations cache TTL                              |
+|             `production.env.threescalePortalEndpoint`             | `string`  |     Yes      |                   -                   |                        Endpoint to request proxy configurations to                        |
+|                 `production.env.apicastLogLevel`                  | `string`  |      No      |                `warn`                 |                                    Openresty log level                                    |
+|               `production.env.apicastOIDCLogLevel`                | `string`  |      No      |               `notice`                |                           OpenID Connect integration log level                            |
+|                   `production.marin3r.enabled`                    | `boolean` |     Yes      |                   -                   |                       Enable (`true`) or disable (`false`) marin3r                        |
+|                `production.marin3r.annotations.{}`                |   `map`   |      No      |                   -                   |                                Map of marin3r annotations                                 |
+|                `production.resources.requests.cpu`                | `string`  |      No      |                `500m`                 |                                   Override CPU requests                                   |
+|              `production.resources.requests.memory`               | `string`  |      No      |                `64Mi`                 |                                 Override Memory requests                                  |
+|                 `production.resources.limits.cpu`                 | `string`  |      No      |                  `1`                  |                                    Override CPU limits                                    |
+|               `production.resources.limits.memory`                | `string`  |      No      |                `128Mi`                |                                  Override Memory limits                                   |
+|          `production.livenessProbe.initialDelaySeconds`           |   `int`   |      No      |                  `5`                  |                         Override liveness initial delay (seconds)                         |
+|             `production.livenessProbe.timeoutSeconds`             |   `int`   |      No      |                  `5`                  |                            Override liveness timeout (seconds)                            |
+|             `production.livenessProbe.periodSeconds`              |   `int`   |      No      |                 `10`                  |                            Override liveness period (seconds)                             |
+|            `production.livenessProbe.successThreshold`            |   `int`   |      No      |                  `1`                  |                            Override liveness success threshold                            |
+|            `production.livenessProbe.failureThreshold`            |   `int`   |      No      |                  `3`                  |                            Override liveness failure threshold                            |
+|          `production.readinessProbe.initialDelaySeconds`          |   `int`   |      No      |                  `5`                  |                        Override readiness initial delay (seconds)                         |
+|            `production.readinessProbe.timeoutSeconds`             |   `int`   |      No      |                  `5`                  |                           Override readiness timeout (seconds)                            |
+|             `production.readinessProbe.periodSeconds`             |   `int`   |      No      |                 `30`                  |                            Override readiness period (seconds)                            |
+|           `production.readinessProbe.successThreshold`            |   `int`   |      No      |                  `1`                  |                           Override readiness success threshold                            |
+|           `production.readinessProbe.failureThreshold`            |   `int`   |      No      |                  `3`                  |                           Override readiness failure threshold                            |
+|                 `production.externalDnsHostname`                  | `string`  |     Yes      |                   -                   |                  DNS hostnames to manage on AWS Route53 by external-dns                   |
+|              `production.loadBalancer.proxyProtocol`              | `string`  |      No      |                  `*`                  |         Proxy protocol enabled (k8s aws provider only accepts `*` by the moment)          |
+|      `production.loadBalancer.crossZoneLoadBalancingEnabled`      |  `bool`   |      No      |                `true`                 |              Enable (`true`) or disable (`false`) cross zone load balancing               |
+|        `production.loadBalancer.connectionDrainingEnabled`        |  `bool`   |      No      |                `true`                 |                 Enable (`true`) or disable (`false`) connection draining                  |
+|        `production.loadBalancer.connectionDrainingTimeout`        |   `int`   |      No      |                 `60`                  |                           Connection draining timeout (seconds)                           |
+|  `production.loadBalancer.connectionHealthcheckHealthyThreshold`  |   `int`   |      No      |                  `2`                  |                         Connection healthcheck healthy threshold                          |
+| `production.loadBalancer.connectionHealthcheckUnhealthyThreshold` |   `int`   |      No      |                  `2`                  |                        Connection healthcheck unhealthy threshold                         |
+|      `production.loadBalancer.connectionHealthcheckInterval`      |   `int`   |      No      |                  `5`                  |                         Connection healthcheck interval (seconds)                         |
+|      `production.loadBalancer.connectionHealthcheckTimeout`       |   `int`   |      No      |                  `3`                  |                         Connection healthcheck timeout (seconds)                          |
+|                   `grafanaDashboard.label.key`                    | `string`  |      No      |           `monitoring-key`            |               Label `key` used by grafana-operator for dashboard discovery                |
+|                  `grafanaDashboard.label.value`                   | `string`  |      No      |             `middleware`              |              Label `value` used by grafana-operator for dashboard discovery               |

--- a/roles/apicast/defaults/main.yml
+++ b/roles/apicast/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 ## Deployment
-replicas: 1
+replicas: 2
 image_name: "quay.io/3scale/apicast-cloud-hosted"
 apicast_log_level: warn
 apicast_oidc_log_level: notice

--- a/roles/apicast/defaults/main.yml
+++ b/roles/apicast/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
 ## Deployment
+pdb_max_unavailable: 1
 replicas: 2
 image_name: "quay.io/3scale/apicast-cloud-hosted"
 apicast_log_level: warn

--- a/roles/apicast/defaults/main.yml
+++ b/roles/apicast/defaults/main.yml
@@ -2,6 +2,10 @@
 
 ## Deployment
 pdb_max_unavailable: 1
+hpa_min_replicas: 2
+hpa_max_replicas: 4
+hpa_resource_name: "cpu"
+hpa_resource_utilization: 90
 replicas: 2
 image_name: "quay.io/3scale/apicast-cloud-hosted"
 apicast_log_level: warn

--- a/roles/apicast/tasks/main.yml
+++ b/roles/apicast/tasks/main.yml
@@ -1,6 +1,17 @@
 ---
 - set_fact:
     apicast_env: staging
+    pdb_state: present
+
+- name: Convert staging.pdb.enabled boolean var into ansible pdb_state state var for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    pdb_state: "absent"
+  when: staging.pdb.enabled is defined and staging.pdb.enabled|bool == false
+
+- name: Manage staging PodDisruptiveBudget for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ pdb_state }}"
+    definition: "{{ lookup('template', 'apicast-pdb.yaml') }}"
 
 - name: Manage staging Deployment for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
@@ -20,6 +31,17 @@
 
 - set_fact:
     apicast_env: production
+    pdb_state: present
+
+- name: Convert production.pdb.enabled boolean var into ansible pdb_state state var for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    pdb_state: "absent"
+  when: production.pdb.enabled is defined and production.pdb.enabled|bool == false
+
+- name: Manage production PodDisruptiveBudget for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ pdb_state }}"
+    definition: "{{ lookup('template', 'apicast-pdb.yaml') }}"
 
 - name: Manage production Deployment for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:

--- a/roles/apicast/tasks/main.yml
+++ b/roles/apicast/tasks/main.yml
@@ -2,16 +2,27 @@
 - set_fact:
     apicast_env: staging
     pdb_state: present
+    hpa_state: present
 
 - name: Convert staging.pdb.enabled boolean var into ansible pdb_state state var for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
   set_fact:
     pdb_state: "absent"
   when: staging.pdb.enabled is defined and staging.pdb.enabled|bool == false
 
-- name: Manage staging PodDisruptiveBudget for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
+- name: Manage staging PodDisruptionBudget for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     state: "{{ pdb_state }}"
     definition: "{{ lookup('template', 'apicast-pdb.yaml') }}"
+
+- name: Convert staging.hpa.enabled boolean var into ansible hpa_state state var for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    hpa_state: "absent"
+  when: staging.hpa.enabled is defined and staging.hpa.enabled|bool == false
+
+- name: Manage staging HoritzontalPodAutoscaler for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ hpa_state }}"
+    definition: "{{ lookup('template', 'apicast-hpa.yaml') }}"
 
 - name: Manage staging Deployment for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
@@ -32,16 +43,27 @@
 - set_fact:
     apicast_env: production
     pdb_state: present
+    hpa_state: present
 
 - name: Convert production.pdb.enabled boolean var into ansible pdb_state state var for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
   set_fact:
     pdb_state: "absent"
   when: production.pdb.enabled is defined and production.pdb.enabled|bool == false
 
-- name: Manage production PodDisruptiveBudget for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
+- name: Manage production PodDisruptionBudget for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     state: "{{ pdb_state }}"
     definition: "{{ lookup('template', 'apicast-pdb.yaml') }}"
+
+- name: Convert production.hpa.enabled boolean var into ansible hpa_state state var for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    hpa_state: "absent"
+  when: production.hpa.enabled is defined and production.hpa.enabled|bool == false
+
+- name: Manage production HoritzontalPodAutoscaler for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ hpa_state }}"
+    definition: "{{ lookup('template', 'apicast-hpa.yaml') }}"
 
 - name: Manage production Deployment for Apicast {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:

--- a/roles/apicast/templates/apicast-deployment.yaml
+++ b/roles/apicast/templates/apicast-deployment.yaml
@@ -107,4 +107,18 @@ spec:
             periodSeconds: {{ vars[apicast_env].readiness_probe.period_seconds | default (readiness_probe_period_seconds) }}
             successThreshold: {{ vars[apicast_env].readiness_probe.success_threshold | default(readiness_probe_success_threshold) }}
             failureThreshold: {{ vars[apicast_env].readiness_probe.failure_threshold | default(readiness_probe_failure_threshold) }}
-
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  deployment: "apicast-{{ apicast_env }}"
+          - weight: 99
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  deployment: "apicast-{{ apicast_env }}"

--- a/roles/apicast/templates/apicast-deployment.yaml
+++ b/roles/apicast/templates/apicast-deployment.yaml
@@ -17,7 +17,9 @@ spec:
       # max number of pods instead
       maxSurge: 1
       maxUnavailable: 0
+{% if vars[apicast_env].hpa.enabled is defined and vars[apicast_env].hpa.enabled == false %}
   replicas: {{ vars[apicast_env].replicas | default(replicas) }}
+{% endif %}
   template:
     metadata:
       labels:

--- a/roles/apicast/templates/apicast-hpa.yaml
+++ b/roles/apicast/templates/apicast-hpa.yaml
@@ -1,0 +1,23 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "apicast-{{ apicast_env }}"
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: 3scale-api-management
+    threescale_component: "apicast-{{ apicast_env }}"
+    threescale_component_element: gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: "apicast-{{ apicast_env }}"
+  minReplicas: {{ vars[apicast_env].hpa.min_replicas | default(hpa_min_replicas) }}
+  maxReplicas: {{ vars[apicast_env].hpa.max_replicas | default(hpa_max_replicas) }}
+  metrics:
+  - type: Resource
+    resource:
+      name: "{{ vars[apicast_env].hpa.resource_name | default(hpa_resource_name) }}"
+      target:
+        type: Utilization
+        averageUtilization: {{ vars[apicast_env].hpa.resource_utilization | default(hpa_resource_utilization) }}

--- a/roles/apicast/templates/apicast-pdb.yaml
+++ b/roles/apicast/templates/apicast-pdb.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: "apicast-{{ apicast_env }}"
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: 3scale-api-management
+    threescale_component: "apicast-{{ apicast_env }}"
+    threescale_component_element: gateway
+spec:
+{% if vars[apicast_env].pdb.min_available is not defined %}
+  maxUnavailable: {{ vars[apicast_env].pdb.max_unavailable | default(pdb_max_unavailable) }}
+{% endif %}
+{% if vars[apicast_env].pdb.min_available is defined %}
+  minAvailable: {{ vars[apicast_env].pdb.min_available }}
+{% endif %}
+  selector:
+    matchLabels:
+      deployment: "apicast-{{ apicast_env }}"


### PR DESCRIPTION
Solves part of https://github.com/3scale/saas-operator/issues/33:
- Update default number of replicas to 2 (like the rest of controllers)
- Add PodDisruptionBudget to apicast deployments
- Add HorizontalPodAutoscaler to apicast deployments
- Add podAntiaffinity to apicast deployments
- Update Apicast CRD with new supported pdb/hpa fields
- Update documentation with new supported pdb/hpa fields