### PR TITLE
Feature/Add HA to Zync controller

### DIFF
--- a/deploy/crds/saas.3scale.net_zyncs_crd.yaml
+++ b/deploy/crds/saas.3scale.net_zyncs_crd.yaml
@@ -58,9 +58,44 @@ spec:
             zync:
               type: object
               properties:
+                pdb:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) PodDisruptionBudget
+                    maxUnavailable:
+                      type: string
+                      pattern: "^[0-9]+%?$"
+                      description: Maximum number of unavailable pods (number or percentage of pods)
+                    minAvailable:
+                      type: string
+                      pattern: "^[0-9]+%?$"
+                      description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
+                hpa:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) HoritzontalPodAutoscaler
+                    minReplicas:
+                      type: integer
+                      description: Minimum number of replicas
+                    maxReplicas:
+                      type: integer
+                      description: Maximum number of replicas
+                    resourceName:
+                      type: string
+                      description: Resource used for autoscale (cpu/memory)
+                      enum:
+                      - cpu
+                      - memory
+                    resourceUtilization:
+                      type: integer
+                      description: Percentage usage of the resource used for autoscale
                 replicas:
                   type: integer
-                  description: Number of replicas
+                  description: Number of replicas (ignored if hpa is enabled)
                 env:
                   type: object
                   properties:
@@ -125,9 +160,44 @@ spec:
             que:
               type: object
               properties:
+                pdb:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) PodDisruptionBudget
+                    maxUnavailable:
+                      type: string
+                      pattern: "^[0-9]+%?$"
+                      description: Maximum number of unavailable pods (number or percentage of pods)
+                    minAvailable:
+                      type: string
+                      pattern: "^[0-9]+%?$"
+                      description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
+                hpa:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enable (true) or disable (false) HoritzontalPodAutoscaler
+                    minReplicas:
+                      type: integer
+                      description: Minimum number of replicas
+                    maxReplicas:
+                      type: integer
+                      description: Maximum number of replicas
+                    resourceName:
+                      type: string
+                      description: Resource used for autoscale (cpu/memory)
+                      enum:
+                      - cpu
+                      - memory
+                    resourceUtilization:
+                      type: integer
+                      description: Percentage usage of the resource used for autoscale
                 replicas:
                   type: integer
-                  description: Number of replicas
+                  description: Number of replicas (ignored if hpa is enabled)
                 env:
                   type: object
                   properties:

--- a/docs/zync-crd-reference.md
+++ b/docs/zync-crd-reference.md
@@ -37,7 +37,15 @@ spec:
   secret:
     vaultPath: secret/data/openshift/dev-example-4-3/3scale-zync
   zync:
-    replicas: 2
+    pdb:
+      enabled: true
+      maxUnavailable: "1"
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 4
+      resourceName: cpu
+      resourceUtilization: 90
     env:
       railsEnv: development
     resources:
@@ -60,7 +68,15 @@ spec:
       successThreshold: 1
       failureThreshold: 5
   que:
-    replicas: 2
+    pdb:
+      enabled: true
+      minAvailable: "80%"
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 4
+      resourceName: cpu
+      resourceUtilization: 90
     env:
       railsEnv: development
     resources:
@@ -90,43 +106,59 @@ spec:
 
 ## CR Spec
 
-|                 **Field**                 | **Type** | **Required** |   **Default value**   |                        **Description**                         |
-| :---------------------------------------: | :------: | :----------: | :-------------------: | :------------------------------------------------------------: |
-|               `image.name`                | `string` |      No      | `quay.io/3scale/zync` |            Image name (docker repository) for zync             |
-|                `image.tag`                | `string` |      No      |       `nightly`       |                       Image tag for zync                       |
-|          `image.pullSecretName`           | `string` |      No      |           -           |    Pull secret for private container repository if required    |
-|            `secret.vaultPath`             | `string` |     Yes      |           -           |                Vault path with the zync secrets                |
-|            `zync.env.railsEnv`            | `string` |      No      |     `development`     |    Rails environment for zync (test/development/production)    |
-|              `zync.replicas`              |  `int`   |      No      |          `2`          |                  Number of replicas for zync                   |
-|       `zync.resources.requests.cpu`       | `string` |      No      |        `250m`         |                 Override CPU requests for zync                 |
-|     `zync.resources.requests.memory`      | `string` |      No      |        `250Mi`        |               Override Memory requests for zync                |
-|        `zync.resources.limits.cpu`        | `string` |      No      |        `750m`         |                  Override CPU limits for zync                  |
-|      `zync.resources.limits.memory`       | `string` |      No      |        `512Mi`        |                Override Memory limits for zync                 |
-| `zync.livenessProbe.initialDelaySeconds`  |  `int`   |      No      |         `10`          |       Override liveness initial delay (seconds) for zync       |
-|    `zync.livenessProbe.timeoutSeconds`    |  `int`   |      No      |         `30`          |          Override liveness timeout (seconds) for zync          |
-|    `zync.livenessProbe.periodSeconds`     |  `int`   |      No      |         `10`          |          Override liveness period (seconds) for zync           |
-|   `zync.livenessProbe.successThreshold`   |  `int`   |      No      |          `1`          |          Override liveness success threshold for zync          |
-|   `zync.livenessProbe.failureThreshold`   |  `int`   |      No      |          `3`          |          Override liveness failure threshold for zync          |
-| `zync.readinessProbe.initialDelaySeconds` |  `int`   |      No      |         `30`          |      Override readiness initial delay (seconds) for zync       |
-|   `zync.readinessProbe.timeoutSeconds`    |  `int`   |      No      |         `10`          |         Override readiness timeout (seconds) for zync          |
-|    `zync.readinessProbe.periodSeconds`    |  `int`   |      No      |         `10`          |          Override readiness period (seconds) for zync          |
-|  `zync.readinessProbe.successThreshold`   |  `int`   |      No      |          `1`          |         Override readiness success threshold for zync          |
-|  `zync.readinessProbe.failureThreshold`   |  `int`   |      No      |          `3`          |         Override readiness failure threshold for zync          |
-|              `que.replicas`               |  `int`   |      No      |          `2`          |                Number of replicas for zync-que                 |
-|            `que.env.railsEnv`             | `string` |      No      |     `development`     |  Rails environment for zync-que (test/development/production)  |
-|       `que.resources.requests.cpu`        | `string` |      No      |        `250m`         |               Override CPU requests for zync-que               |
-|      `que.resources.requests.memory`      | `string` |      No      |        `250Mi`        |             Override Memory requests for zync-que              |
-|        `que.resources.limits.cpu`         | `string` |      No      |        `750m`         |                Override CPU limits for zync-que                |
-|       `que.resources.limits.memory`       | `string` |      No      |        `512Mi`        |              Override Memory limits for zync-que               |
-|  `que.livenessProbe.initialDelaySeconds`  |  `int`   |      No      |         `10`          |     Override liveness initial delay (seconds) for zync-que     |
-|    `que.livenessProbe.timeoutSeconds`     |  `int`   |      No      |         `30`          |        Override liveness timeout (seconds) for zync-que        |
-|     `que.livenessProbe.periodSeconds`     |  `int`   |      No      |         `10`          |        Override liveness period (seconds) for zync-que         |
-|   `que.livenessProbe.successThreshold`    |  `int`   |      No      |          `1`          |        Override liveness success threshold for zync-que        |
-|   `que.livenessProbe.failureThreshold`    |  `int`   |      No      |          `3`          |        Override liveness failure threshold for zync-que        |
-| `que.readinessProbe.initialDelaySeconds`  |  `int`   |      No      |         `30`          |    Override readiness initial delay (seconds) for zync-que     |
-|    `que.readinessProbe.timeoutSeconds`    |  `int`   |      No      |         `10`          |       Override readiness timeout (seconds) for zync-que        |
-|    `que.readinessProbe.periodSeconds`     |  `int`   |      No      |         `10`          |        Override readiness period (seconds) for zync-que        |
-|   `que.readinessProbe.successThreshold`   |  `int`   |      No      |          `1`          |       Override readiness success threshold for zync-que        |
-|   `que.readinessProbe.failureThreshold`   |  `int`   |      No      |          `3`          |       Override readiness failure threshold for zync-que        |
-|       `grafanaDashboard.label.key`        | `string` |      No      |   `monitoring-key`    |  Label `key` used by grafana-operator for dashboard discovery  |
-|      `grafanaDashboard.label.value`       | `string` |      No      |     `middleware`      | Label `value` used by grafana-operator for dashboard discovery |
+|                 **Field**                 | **Type**  | **Required** |   **Default value**   |                                      **Description**                                      |
+| :---------------------------------------: | :-------: | :----------: | :-------------------: | :---------------------------------------------------------------------------------------: |
+|               `image.name`                | `string`  |      No      | `quay.io/3scale/zync` |                          Image name (docker repository) for zync                          |
+|                `image.tag`                | `string`  |      No      |       `nightly`       |                                    Image tag for zync                                     |
+|          `image.pullSecretName`           | `string`  |      No      |           -           |                 Pull secret for private container repository if required                  |
+|            `secret.vaultPath`             | `string`  |     Yes      |           -           |                             Vault path with the zync secrets                              |
+|            `zync.pdb.enabled`             | `boolean` |      No      |        `true`         |                 Enable (`true`) or disable (`false`) PodDisruptionBudget                  |
+|         `zync.pdb.maxUnavailable`         | `string`  |      No      |          `1`          |             Maximum number of unavailable pods (number or percentage of pods)             |
+|          `zync.pdb.minAvailable`          | `string`  |      No      |           -           | Minimum number of available pods (number or percentage of pods), overrides maxUnavailable |
+|            `zync.hpa.enabled`             | `boolean` |      No      |        `true`         |               Enable (`true`) or disable (`false`) HoritzontalPodAutoscaler               |
+|          `zync.hpa.minReplicas`           |   `int`   |      No      |          `2`          |                                Minimum number of replicas                                 |
+|          `zync.hpa.maxReplicas`           |   `int`   |      No      |          `4`          |                                Maximum number of replicas                                 |
+|          `zync.hpa.resourceName`          | `string`  |      No      |         `cpu`         |                         Resource used for autoscale (cpu/memory)                          |
+|      `zync.hpa.resourceUtilization`       |   `int`   |      No      |         `90`          |                    Percentage usage of the resource used for autoscale                    |
+|              `zync.replicas`              |   `int`   |      No      |          `2`          |                  Number of replicas for zync (ignored if hpa is enabled)                  |
+|            `zync.env.railsEnv`            | `string`  |      No      |     `development`     |                 Rails environment for zync (test/development/production)                  |
+|       `zync.resources.requests.cpu`       | `string`  |      No      |        `250m`         |                              Override CPU requests for zync                               |
+|     `zync.resources.requests.memory`      | `string`  |      No      |        `250Mi`        |                             Override Memory requests for zync                             |
+|        `zync.resources.limits.cpu`        | `string`  |      No      |        `750m`         |                               Override CPU limits for zync                                |
+|      `zync.resources.limits.memory`       | `string`  |      No      |        `512Mi`        |                              Override Memory limits for zync                              |
+| `zync.livenessProbe.initialDelaySeconds`  |   `int`   |      No      |         `10`          |                    Override liveness initial delay (seconds) for zync                     |
+|    `zync.livenessProbe.timeoutSeconds`    |   `int`   |      No      |         `30`          |                       Override liveness timeout (seconds) for zync                        |
+|    `zync.livenessProbe.periodSeconds`     |   `int`   |      No      |         `10`          |                        Override liveness period (seconds) for zync                        |
+|   `zync.livenessProbe.successThreshold`   |   `int`   |      No      |          `1`          |                       Override liveness success threshold for zync                        |
+|   `zync.livenessProbe.failureThreshold`   |   `int`   |      No      |          `3`          |                       Override liveness failure threshold for zync                        |
+| `zync.readinessProbe.initialDelaySeconds` |   `int`   |      No      |         `30`          |                    Override readiness initial delay (seconds) for zync                    |
+|   `zync.readinessProbe.timeoutSeconds`    |   `int`   |      No      |         `10`          |                       Override readiness timeout (seconds) for zync                       |
+|    `zync.readinessProbe.periodSeconds`    |   `int`   |      No      |         `10`          |                       Override readiness period (seconds) for zync                        |
+|  `zync.readinessProbe.successThreshold`   |   `int`   |      No      |          `1`          |                       Override readiness success threshold for zync                       |
+|  `zync.readinessProbe.failureThreshold`   |   `int`   |      No      |          `3`          |                       Override readiness failure threshold for zync                       |
+|             `que.pdb.enabled`             | `boolean` |      No      |        `true`         |                 Enable (`true`) or disable (`false`) PodDisruptionBudget                  |
+|         `que.pdb.maxUnavailable`          | `string`  |      No      |          `1`          |             Maximum number of unavailable pods (number or percentage of pods)             |
+|          `que.pdb.minAvailable`           | `string`  |      No      |           -           | Minimum number of available pods (number or percentage of pods), overrides maxUnavailable |
+|             `que.hpa.enabled`             | `boolean` |      No      |        `true`         |               Enable (`true`) or disable (`false`) HoritzontalPodAutoscaler               |
+|           `que.hpa.minReplicas`           |   `int`   |      No      |          `2`          |                                Minimum number of replicas                                 |
+|           `que.hpa.maxReplicas`           |   `int`   |      No      |          `4`          |                                Maximum number of replicas                                 |
+|          `que.hpa.resourceName`           | `string`  |      No      |         `cpu`         |                         Resource used for autoscale (cpu/memory)                          |
+|       `que.hpa.resourceUtilization`       |   `int`   |      No      |         `90`          |                    Percentage usage of the resource used for autoscale                    |
+|              `que.replicas`               |   `int`   |      No      |          `2`          |                Number of replicas for zync-que (ignored if hpa is enabled)                |
+|            `que.env.railsEnv`             | `string`  |      No      |     `development`     |               Rails environment for zync-que (test/development/production)                |
+|       `que.resources.requests.cpu`        | `string`  |      No      |        `250m`         |                            Override CPU requests for zync-que                             |
+|      `que.resources.requests.memory`      | `string`  |      No      |        `250Mi`        |                           Override Memory requests for zync-que                           |
+|        `que.resources.limits.cpu`         | `string`  |      No      |        `750m`         |                             Override CPU limits for zync-que                              |
+|       `que.resources.limits.memory`       | `string`  |      No      |        `512Mi`        |                            Override Memory limits for zync-que                            |
+|  `que.livenessProbe.initialDelaySeconds`  |   `int`   |      No      |         `10`          |                  Override liveness initial delay (seconds) for zync-que                   |
+|    `que.livenessProbe.timeoutSeconds`     |   `int`   |      No      |         `30`          |                     Override liveness timeout (seconds) for zync-que                      |
+|     `que.livenessProbe.periodSeconds`     |   `int`   |      No      |         `10`          |                      Override liveness period (seconds) for zync-que                      |
+|   `que.livenessProbe.successThreshold`    |   `int`   |      No      |          `1`          |                     Override liveness success threshold for zync-que                      |
+|   `que.livenessProbe.failureThreshold`    |   `int`   |      No      |          `3`          |                     Override liveness failure threshold for zync-que                      |
+| `que.readinessProbe.initialDelaySeconds`  |   `int`   |      No      |         `30`          |                  Override readiness initial delay (seconds) for zync-que                  |
+|    `que.readinessProbe.timeoutSeconds`    |   `int`   |      No      |         `10`          |                     Override readiness timeout (seconds) for zync-que                     |
+|    `que.readinessProbe.periodSeconds`     |   `int`   |      No      |         `10`          |                     Override readiness period (seconds) for zync-que                      |
+|   `que.readinessProbe.successThreshold`   |   `int`   |      No      |          `1`          |                     Override readiness success threshold for zync-que                     |
+|   `que.readinessProbe.failureThreshold`   |   `int`   |      No      |          `3`          |                     Override readiness failure threshold for zync-que                     |
+|       `grafanaDashboard.label.key`        | `string`  |      No      |   `monitoring-key`    |               Label `key` used by grafana-operator for dashboard discovery                |
+|      `grafanaDashboard.label.value`       | `string`  |      No      |     `middleware`      |              Label `value` used by grafana-operator for dashboard discovery               |

--- a/roles/zync/defaults/main.yml
+++ b/roles/zync/defaults/main.yml
@@ -4,6 +4,13 @@ image_name: "quay.io/3scale/zync"
 image_tag: "nightly"
 
 ## Zync Deployment
+zync_pdb_state: "present"
+zync_pdb_max_unavailable: 1
+zync_hpa_state: "present"
+zync_hpa_min_replicas: 2
+zync_hpa_max_replicas: 4
+zync_hpa_resource_name: "cpu"
+zync_hpa_resource_utilization: 90
 zync_replicas: 2
 ### Zync Deployment Env
 zync_env_rails_env: "development"
@@ -26,6 +33,13 @@ zync_readiness_probe_success_threshold: 1
 zync_readiness_probe_failure_threshold: 3
 
 ## Zync-Que Deployment
+que_pdb_state: "present"
+que_pdb_max_unavailable: 1
+que_hpa_state: "present"
+que_hpa_min_replicas: 2
+que_hpa_max_replicas: 4
+que_hpa_resource_name: "cpu"
+que_hpa_resource_utilization: 90
 que_replicas: 2
 ### Zync Deployment Env
 que_env_rails_env: "development"

--- a/roles/zync/tasks/main.yml
+++ b/roles/zync/tasks/main.yml
@@ -4,6 +4,26 @@
   k8s:
     definition: "{{ lookup('template', 'zync-secretdefinition.yaml') }}"
 
+- name: Convert que.pdb.enabled boolean var into ansible que_pdb_state state var for Zync {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    que_pdb_state: "absent"
+  when: que.pdb.enabled is defined and que.pdb.enabled|bool == false
+
+- name: Manage zync-que PodDisruptionBudget for Zync {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ que_pdb_state }}"
+    definition: "{{ lookup('template', 'zync-que-pdb.yaml') }}"
+
+- name: Convert que.hpa.enabled boolean var into ansible que_hpa_state state var for Zync {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    que_hpa_state: "absent"
+  when: que.hpa.enabled is defined and que.hpa.enabled|bool == false
+
+- name: Manage zync-que HoritzontalPodAutoscaler for Zync {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ que_hpa_state }}"
+    definition: "{{ lookup('template', 'zync-que-hpa.yaml') }}"
+
 - name: Manage zync-que Deployment for Zync {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     definition: "{{ lookup('template', 'zync-que-deployment.yaml') }}"
@@ -11,6 +31,26 @@
 - name: Manage zync-que PodMonitor for Zync {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     definition: "{{ lookup('template', 'zync-que-podmonitor.yaml') }}"
+
+- name: Convert zync.pdb.enabled boolean var into ansible zync_pdb_state state var for Zync {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    zync_pdb_state: "absent"
+  when: zync.pdb.enabled is defined and zync.pdb.enabled|bool == false
+
+- name: Manage zync PodDisruptionBudget for Zync {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ zync_pdb_state }}"
+    definition: "{{ lookup('template', 'zync-pdb.yaml') }}"
+
+- name: Convert zync.hpa.enabled boolean var into ansible zync_hpa_state state var for Zync {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    zync_hpa_state: "absent"
+  when: zync.hpa.enabled is defined and zync.hpa.enabled|bool == false
+
+- name: Manage zync HoritzontalPodAutoscaler for Zync {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ zync_hpa_state }}"
+    definition: "{{ lookup('template', 'zync-hpa.yaml') }}"
 
 - name: Manage zync Deployment for Zync {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:

--- a/roles/zync/templates/zync-deployment.yaml
+++ b/roles/zync/templates/zync-deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     threescale_component: zync
     threescale_component_element: zync
 spec:
+{% if zync.hpa.enabled is defined and zync.hpa.enabled == false %}
   replicas: {{ zync.replicas | default(zync_replicas) }}
+{% endif %}
   selector:
     matchLabels:
       deployment: zync

--- a/roles/zync/templates/zync-deployment.yaml
+++ b/roles/zync/templates/zync-deployment.yaml
@@ -105,3 +105,18 @@ spec:
               secretKeyRef:
                 key: ZYNC_AUTHENTICATION_TOKEN
                 name: zync
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  deployment: zync
+          - weight: 99
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  deployment: zync

--- a/roles/zync/templates/zync-hpa.yaml
+++ b/roles/zync/templates/zync-hpa.yaml
@@ -1,0 +1,23 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: zync
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: 3scale-api-management
+    threescale_component: zync
+    threescale_component_element: zync
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: zync
+  minReplicas: {{ zync.hpa.min_replicas | default(zync_hpa_min_replicas) }}
+  maxReplicas: {{ zync.hpa.max_replicas | default(zync_hpa_max_replicas) }}
+  metrics:
+  - type: Resource
+    resource:
+      name: "{{ zync.hpa.resource_name | default(zync_hpa_resource_name) }}"
+      target:
+        type: Utilization
+        averageUtilization: {{ zync.hpa.resource_utilization | default(zync_hpa_resource_utilization) }}

--- a/roles/zync/templates/zync-pdb.yaml
+++ b/roles/zync/templates/zync-pdb.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zync
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: 3scale-api-management
+    threescale_component: zync
+    threescale_component_element: zync
+spec:
+{% if zync.pdb.min_available is not defined %}
+  maxUnavailable: {{ zync.pdb.max_unavailable | default(zync_pdb_max_unavailable) }}
+{% endif %}
+{% if zync.pdb.min_available is defined %}
+  minAvailable: {{ zync.pdb.min_available }}
+{% endif %}
+  selector:
+    matchLabels:
+      deployment: zync

--- a/roles/zync/templates/zync-que-deployment.yaml
+++ b/roles/zync/templates/zync-que-deployment.yaml
@@ -104,3 +104,18 @@ spec:
               secretKeyRef:
                 key: ZYNC_AUTHENTICATION_TOKEN
                 name: zync
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  deployment: zync-que
+          - weight: 99
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  deployment: zync-que

--- a/roles/zync/templates/zync-que-deployment.yaml
+++ b/roles/zync/templates/zync-que-deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     threescale_component: zync
     threescale_component_element: zync-que
 spec:
+{% if que.hpa.enabled is defined and que.hpa.enabled == false %}
   replicas: {{ que.replicas | default(que_replicas) }}
+{% endif %}
   selector:
     matchLabels:
       deployment: zync-que

--- a/roles/zync/templates/zync-que-hpa.yaml
+++ b/roles/zync/templates/zync-que-hpa.yaml
@@ -1,0 +1,23 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: zync-que
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: 3scale-api-management
+    threescale_component: zync
+    threescale_component_element: zync-que
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: zync-que
+  minReplicas: {{ que.hpa.min_replicas | default(que_hpa_min_replicas) }}
+  maxReplicas: {{ que.hpa.max_replicas | default(que_hpa_max_replicas) }}
+  metrics:
+  - type: Resource
+    resource:
+      name: "{{ que.hpa.resource_name | default(que_hpa_resource_name) }}"
+      target:
+        type: Utilization
+        averageUtilization: {{ que.hpa.resource_utilization | default(que_hpa_resource_utilization) }}

--- a/roles/zync/templates/zync-que-pdb.yaml
+++ b/roles/zync/templates/zync-que-pdb.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zync-que
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: 3scale-api-management
+    threescale_component: zync
+    threescale_component_element: zync-que
+spec:
+{% if que.pdb.min_available is not defined %}
+  maxUnavailable: {{ que.pdb.max_unavailable | default(que_pdb_max_unavailable) }}
+{% endif %}
+{% if que.pdb.min_available is defined %}
+  minAvailable: {{ que.pdb.min_available }}
+{% endif %}
+  selector:
+    matchLabels:
+      deployment: zync-que


### PR DESCRIPTION
Solves part of https://github.com/3scale/saas-operator/issues/33:
- Add PodDisruptionBudget to zync deployments
- Add HorizontalPodAutoscaler to zync deployments
- Add podAntiaffinity to zync deployments
- Update Zync CRD with new supported pdb/hpa fields
- Update Zync documentation with new supported pdb/hpa fields