### PR TITLE
Feature/Add HA to CORSProxy controller

### DIFF
--- a/deploy/crds/saas.3scale.net_corsproxies_crd.yaml
+++ b/deploy/crds/saas.3scale.net_corsproxies_crd.yaml
@@ -56,9 +56,44 @@ spec:
                 systemDatabaseVaultPath:
                   type: string
                   description: Vault Path with cors-proxy-system-database secret definition
+            pdb:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: Enable (true) or disable (false) PodDisruptionBudget
+                maxUnavailable:
+                  type: string
+                  pattern: "^[0-9]+%?$"
+                  description: Maximum number of unavailable pods (number or percentage of pods)
+                minAvailable:
+                  type: string
+                  pattern: "^[0-9]+%?$"
+                  description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
+            hpa:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: Enable (true) or disable (false) HoritzontalPodAutoscaler
+                minReplicas:
+                  type: integer
+                  description: Minimum number of replicas
+                maxReplicas:
+                  type: integer
+                  description: Maximum number of replicas
+                resourceName:
+                  type: string
+                  description: Resource used for autoscale (cpu/memory)
+                  enum:
+                  - cpu
+                  - memory
+                resourceUtilization:
+                  type: integer
+                  description: Percentage usage of the resource used for autoscale
             replicas:
               type: integer
-              description: Number of replicas
+              description: Number of replicas (ignored if hpa is enabled)
             resources:
               type: object
               properties:

--- a/docs/corsproxy-crd-reference.md
+++ b/docs/corsproxy-crd-reference.md
@@ -34,7 +34,15 @@ spec:
     pullSecretName: quay-pull-secret
   secret:
     systemDatabaseVaultPath: secret/data/openshift/cluster-example/3scale/cors-proxy-system-database
-  replicas: 2
+  pdb:
+    enabled: true
+    maxUnavailable: "1"
+  hpa:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    resourceName: cpu
+    resourceUtilization: 90
   livenessProbe:
     initialDelaySeconds: 3
     timeoutSeconds: 1
@@ -71,6 +79,15 @@ spec:
 | `image.tag` | `string` | No | `v1.1.0` | Image tag |
 | `image.pullSecretName` | `string` | No | - | Quay pull secret for private repository |
 | `secret.systemDatabaseVaultPath` | `string` | Yes | - | Vault Path with cors-proxy-system-database secret definition |
+| `pdb.enabled` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) PodDisruptionBudget |
+| `pdb.maxUnavailable` | `string` | No | `1` | Maximum number of unavailable pods (number or percentage of pods) ** |
+| `pdb.minAvailable` | `string` | No | - | Minimum number of available pods (number or percentage of pods), overrides maxUnavailable ** |
+| `hpa.enabled` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) HoritzontalPodAutoscaler |
+| `hpa.minReplicas` | `int` | No | `2` | Minimum number of replicas |
+| `hpa.maxReplicas` | `int` | No | `4` | Maximum number of replicas |
+| `hpa.resourceName` | `string` | No | `cpu` | Resource used for autoscale (cpu/memory) |
+| `hpa.resourceUtilization` | `int` | No | `90` | Percentage usage of the resource used for autoscale |
+| `replicas` | `int` | No | `2` | Number of replicas (ignored if hpa is enabled) |
 | `replicas` | `int` | No | `2` | Number of replicas |
 | `resources.requests.cpu` | `string` | No | `250m` | Override CPU requests |
 | `resources.requests.memory` | `string` | No | `250Mi` | Override Memory requests |
@@ -90,3 +107,7 @@ spec:
 | `ingress.host` | `string` | Yes | - | Host to configure on Nginx Ingress |
 | `grafanaDashboard.label.key` | `string` | No | `monitoring-key` | Label `key` used by grafana-operator for dashboard discovery |
 | `grafanaDashboard.label.value` | `string` | No | `middleware` | Label `value` used by grafana-operator for dashboard discovery |
+
+** If you are already using `pdb.maxUnavailable` and want to use `pdb.minAvailable` (or the other way around), due to ansible operator limitation of doing patch operation (if objects already exist), operator will receive an error when managing PDB object because although the spec of the PDB resource it creates is correct, operator will try to patch an existing object which already has the other variable, and these two variables `pdb.maxUnavailable`/`pdb.minAvailable` are mutually exclusive and cannot coexists on the same PDB. To solve that situation:
+  - Configure `pdb.enabled=false` (so operator will delete associated PDB, and then re-enable it with `pdb.enabled=true` setting desired PDB field `pdb.minAvailable` or `pdb.maxUnavailable`. so operator will create it from scratch on next reconcile
+  - Or, delete manually associated PDB object, and operator will create it from scratch on next reconcile

--- a/roles/corsproxy/defaults/main.yml
+++ b/roles/corsproxy/defaults/main.yml
@@ -1,6 +1,13 @@
 ---
 
 ## Deployment
+pdb_state: "present"
+pdb_max_unavailable: 1
+hpa_state: "present"
+hpa_min_replicas: 2
+hpa_max_replicas: 4
+hpa_resource_name: "cpu"
+hpa_resource_utilization: 90
 replicas: 2
 image_name: "quay.io/3scale/cors-proxy"
 image_tag: "v1.1.0"

--- a/roles/corsproxy/tasks/main.yml
+++ b/roles/corsproxy/tasks/main.yml
@@ -4,6 +4,25 @@
   k8s:
     definition: "{{ lookup('template', 'cors-proxy-system-database-secretdefinition.yaml') }}"
 
+- name: Convert pdb.enabled boolean var into ansible pdb_state state var for CORSProxy {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    pdb_state: "absent"
+  when: pdb.enabled is defined and pdb.enabled|bool == false
+
+- name: Manage cors-proxy PodDisruptionBudget for CORSProxy {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ pdb_state }}"
+    definition: "{{ lookup('template', 'cors-proxy-pdb.yaml') }}"
+
+- name: Convert hpa.enabled boolean var into ansible hpa_state state var for CORSProxy {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    hpa_state: "absent"
+  when: hpa.enabled is defined and hpa.enabled|bool == false
+
+- name: Manage cors-proxy HoritzontalPodAutoscaler for CORSProxy {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ hpa_state }}"
+    definition: "{{ lookup('template', 'cors-proxy-hpa.yaml') }}"
 - name: Manage cors-proxy Deployment for CORSProxy {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     definition: "{{ lookup('template', 'cors-proxy-deployment.yaml') }}"

--- a/roles/corsproxy/templates/cors-proxy-deployment.yaml
+++ b/roles/corsproxy/templates/cors-proxy-deployment.yaml
@@ -72,6 +72,20 @@ spec:
             limits:
               memory: "{{ resources.limits.memory | default(resources_limits_memory) }}"
               cpu: "{{ resources.limits.cpu | default(resources_limits_cpu) }}"
-
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  deployment: cors-proxy
+          - weight: 99
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  deployment: cors-proxy
 
 

--- a/roles/corsproxy/templates/cors-proxy-deployment.yaml
+++ b/roles/corsproxy/templates/cors-proxy-deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     app: cors-proxy
     part-of: 3scale-saas
 spec:
+{% if hpa.enabled is defined and hpa.enabled == false %}
   replicas: {{ replicas }}
+{% endif %}
   selector:
     matchLabels:
       deployment: cors-proxy

--- a/roles/corsproxy/templates/cors-proxy-hpa.yaml
+++ b/roles/corsproxy/templates/cors-proxy-hpa.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: cors-proxy
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: cors-proxy
+    part-of: 3scale-saas
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cors-proxy
+  minReplicas: {{ hpa.min_replicas | default(hpa_min_replicas) }}
+  maxReplicas: {{ hpa.max_replicas | default(hpa_max_replicas) }}
+  metrics:
+  - type: Resource
+    resource:
+      name: "{{ hpa.resource_name | default(hpa_resource_name) }}"
+      target:
+        type: Utilization
+        averageUtilization: {{ hpa.resource_utilization | default(hpa_resource_utilization) }}

--- a/roles/corsproxy/templates/cors-proxy-pdb.yaml
+++ b/roles/corsproxy/templates/cors-proxy-pdb.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: cors-proxy
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: cors-proxy
+    part-of: 3scale-saas
+spec:
+{% if pdb.min_available is not defined %}
+  maxUnavailable: {{ pdb.max_unavailable | default(pdb_max_unavailable) }}
+{% endif %}
+{% if pdb.min_available is defined %}
+  minAvailable: {{ pdb.min_available }}
+{% endif %}
+  selector:
+    matchLabels:
+      deployment: cors-proxy


### PR DESCRIPTION
Solves part of https://github.com/3scale/saas-operator/issues/33:
- Add PodDisruptionBudget to cors-proxy deployment
- Add HorizontalPodAutoscaler to cors-proxy deployment
- Add podAntiaffinity to cors-proxy deployment
- Update CORSProxy CRD with new supported pdb/hpa fields
- Update CORSProxy documentation with new supported pdb/hpa fields