### PR TITLE
Feature/Add HA to MappingService controller

### DIFF
--- a/deploy/crds/saas.3scale.net_mappingservices_crd.yaml
+++ b/deploy/crds/saas.3scale.net_mappingservices_crd.yaml
@@ -61,9 +61,44 @@ spec:
                 systemAdminTokenVaultPath:
                   type: string
                   description: Vault path containing system's admin token
+            pdb:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: Enable (true) or disable (false) PodDisruptionBudget
+                maxUnavailable:
+                  type: string
+                  pattern: "^[0-9]+%?$"
+                  description: Maximum number of unavailable pods (number or percentage of pods)
+                minAvailable:
+                  type: string
+                  pattern: "^[0-9]+%?$"
+                  description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
+            hpa:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: Enable (true) or disable (false) HoritzontalPodAutoscaler
+                minReplicas:
+                  type: integer
+                  description: Minimum number of replicas
+                maxReplicas:
+                  type: integer
+                  description: Maximum number of replicas
+                resourceName:
+                  type: string
+                  description: Resource used for autoscale (cpu/memory)
+                  enum:
+                  - cpu
+                  - memory
+                resourceUtilization:
+                  type: integer
+                  description: Percentage usage of the resource used for autoscale
             replicas:
               type: integer
-              description: Number of replicas
+              description: Number of replicas (ignored if hpa is enabled)
             env:
               type: object
               description: Environment variables

--- a/docs/mappingservice-crd-reference.md
+++ b/docs/mappingservice-crd-reference.md
@@ -32,7 +32,15 @@ spec:
     name: quay.io/3scale/apicast-cloud-hosted
     tag: mapping-service-v3.8.0-r3
     pullSecretName: quay-pull-secret
-  replicas: 2
+  pdb:
+    enabled: true
+    maxUnavailable: "1"
+  hpa:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    resourceName: cpu
+    resourceUtilization: 90
   env:
     apiHost: http://system:3000
     previewBaseDomain: example.3scale.net
@@ -67,29 +75,41 @@ spec:
 
 ## CR Spec
 
-|              **Field**               | **Type** | **Required** |           **Default value**           |                        **Description**                         |
-| :----------------------------------: | :------: | :----------: | :-----------------------------------: | :------------------------------------------------------------: |
-|             `image.name`             | `string` |      No      | `quay.io/3scale/apicast-cloud-hosted` |                 Image name (docker repository)                 |
-|             `image.tag`              | `string` |     Yes      |                   -                   |                           Image tag                            |
-|        `image.pullSecretName`        | `string` |      No      |                   -                   |            Quay pull secret for private repository             |
-|              `replicas`              |  `int`   |      No      |                  `1`                  |                       Number of replicas                       |
-|            `env.apiHost`             | `string` |     Yes      |                   -                   |          System endpoint to fetch proxy configs from           |
-|       `env.previewBaseDomain`        | `string` |      No      |                   -                   |      Base domain to replace the proxy configs base domain      |
-|        `env.apicastLogLevel`         | `string` |      No      |                `warn`                 |                      Openresty log level                       |
-|  `secret.systemAdminTokenVaultPath`  | `string` |     Yes      |                   -                   | Vault path with system's master access token secret definition |
-|       `resources.requests.cpu`       | `string` |      No      |                `500m`                 |                     Override CPU requests                      |
-|     `resources.requests.memory`      | `string` |      No      |                `64Mi`                 |                    Override Memory requests                    |
-|        `resources.limits.cpu`        | `string` |      No      |                  `1`                  |                      Override CPU limits                       |
-|      `resources.limits.memory`       | `string` |      No      |                `128Mi`                |                     Override Memory limits                     |
-| `livenessProbe.initialDelaySeconds`  |  `int`   |      No      |                  `5`                  |           Override liveness initial delay (seconds)            |
-|    `livenessProbe.timeoutSeconds`    |  `int`   |      No      |                  `5`                  |              Override liveness timeout (seconds)               |
-|    `livenessProbe.periodSeconds`     |  `int`   |      No      |                 `10`                  |               Override liveness period (seconds)               |
-|   `livenessProbe.successThreshold`   |  `int`   |      No      |                  `1`                  |              Override liveness success threshold               |
-|   `livenessProbe.failureThreshold`   |  `int`   |      No      |                  `3`                  |              Override liveness failure threshold               |
-| `readinessProbe.initialDelaySeconds` |  `int`   |      No      |                  `5`                  |           Override readiness initial delay (seconds)           |
-|   `readinessProbe.timeoutSeconds`    |  `int`   |      No      |                  `5`                  |              Override readiness timeout (seconds)              |
-|    `readinessProbe.periodSeconds`    |  `int`   |      No      |                 `30`                  |              Override readiness period (seconds)               |
-|  `readinessProbe.successThreshold`   |  `int`   |      No      |                  `1`                  |              Override readiness success threshold              |
-|  `readinessProbe.failureThreshold`   |  `int`   |      No      |                  `3`                  |              Override readiness failure threshold              |
-|     `grafanaDashboard.label.key`     | `string` |      No      |           `monitoring-key`            |  Label `key` used by grafana-operator for dashboard discovery  |
-|    `grafanaDashboard.label.value`    | `string` |      No      |             `middleware`              | Label `value` used by grafana-operator for dashboard discovery |
+|              **Field**               | **Type**  | **Required** |           **Default value**           |                                       **Description**                                        |
+| :----------------------------------: | :-------: | :----------: | :-----------------------------------: | :------------------------------------------------------------------------------------------: |
+|             `image.name`             | `string`  |      No      | `quay.io/3scale/apicast-cloud-hosted` |                                Image name (docker repository)                                |
+|             `image.tag`              | `string`  |     Yes      |                   -                   |                                          Image tag                                           |
+|        `image.pullSecretName`        | `string`  |      No      |                   -                   |                           Quay pull secret for private repository                            |
+|            `pdb.enabled`             | `boolean` |      No      |                `true`                 |                   Enable (`true`) or disable (`false`) PodDisruptionBudget                   |
+|         `pdb.maxUnavailable`         | `string`  |      No      |                  `1`                  |             Maximum number of unavailable pods (number or percentage of pods) **             |
+|          `pdb.minAvailable`          | `string`  |      No      |                   -                   | Minimum number of available pods (number or percentage of pods), overrides maxUnavailable ** |
+|            `hpa.enabled`             | `boolean` |      No      |                `true`                 |                Enable (`true`) or disable (`false`) HoritzontalPodAutoscaler                 |
+|          `hpa.minReplicas`           |   `int`   |      No      |                  `2`                  |                                  Minimum number of replicas                                  |
+|          `hpa.maxReplicas`           |   `int`   |      No      |                  `4`                  |                                  Maximum number of replicas                                  |
+|          `hpa.resourceName`          | `string`  |      No      |                 `cpu`                 |                           Resource used for autoscale (cpu/memory)                           |
+|      `hpa.resourceUtilization`       |   `int`   |      No      |                 `90`                  |                     Percentage usage of the resource used for autoscale                      |
+|              `replicas`              |   `int`   |      No      |                  `2`                  |                        Number of replicas (ignored if hpa is enabled)                        |
+|            `env.apiHost`             | `string`  |     Yes      |                   -                   |                         System endpoint to fetch proxy configs from                          |
+|       `env.previewBaseDomain`        | `string`  |      No      |                   -                   |                     Base domain to replace the proxy configs base domain                     |
+|        `env.apicastLogLevel`         | `string`  |      No      |                `warn`                 |                                     Openresty log level                                      |
+|  `secret.systemAdminTokenVaultPath`  | `string`  |     Yes      |                   -                   |                Vault path with system's master access token secret definition                |
+|       `resources.requests.cpu`       | `string`  |      No      |                `500m`                 |                                    Override CPU requests                                     |
+|     `resources.requests.memory`      | `string`  |      No      |                `64Mi`                 |                                   Override Memory requests                                   |
+|        `resources.limits.cpu`        | `string`  |      No      |                  `1`                  |                                     Override CPU limits                                      |
+|      `resources.limits.memory`       | `string`  |      No      |                `128Mi`                |                                    Override Memory limits                                    |
+| `livenessProbe.initialDelaySeconds`  |   `int`   |      No      |                  `5`                  |                          Override liveness initial delay (seconds)                           |
+|    `livenessProbe.timeoutSeconds`    |   `int`   |      No      |                  `5`                  |                             Override liveness timeout (seconds)                              |
+|    `livenessProbe.periodSeconds`     |   `int`   |      No      |                 `10`                  |                              Override liveness period (seconds)                              |
+|   `livenessProbe.successThreshold`   |   `int`   |      No      |                  `1`                  |                             Override liveness success threshold                              |
+|   `livenessProbe.failureThreshold`   |   `int`   |      No      |                  `3`                  |                             Override liveness failure threshold                              |
+| `readinessProbe.initialDelaySeconds` |   `int`   |      No      |                  `5`                  |                          Override readiness initial delay (seconds)                          |
+|   `readinessProbe.timeoutSeconds`    |   `int`   |      No      |                  `5`                  |                             Override readiness timeout (seconds)                             |
+|    `readinessProbe.periodSeconds`    |   `int`   |      No      |                 `30`                  |                             Override readiness period (seconds)                              |
+|  `readinessProbe.successThreshold`   |   `int`   |      No      |                  `1`                  |                             Override readiness success threshold                             |
+|  `readinessProbe.failureThreshold`   |   `int`   |      No      |                  `3`                  |                             Override readiness failure threshold                             |
+|     `grafanaDashboard.label.key`     | `string`  |      No      |           `monitoring-key`            |                 Label `key` used by grafana-operator for dashboard discovery                 |
+|    `grafanaDashboard.label.value`    | `string`  |      No      |             `middleware`              |                Label `value` used by grafana-operator for dashboard discovery                |
+
+** If you are already using `pdb.maxUnavailable` and want to use `pdb.minAvailable` (or the other way around), due to ansible operator limitation of doing patch operation (if objects already exist), operator will receive an error when managing PDB object because although the spec of the PDB resource it creates is correct, operator will try to patch an existing object which already has the other variable, and these two variables `pdb.maxUnavailable`/`pdb.minAvailable` are mutually exclusive and cannot coexists on the same PDB. To solve that situation:
+  - Configure `pdb.enabled=false` (so operator will delete associated PDB, and then re-enable it with `pdb.enabled=true` setting desired PDB field `pdb.minAvailable` or `pdb.maxUnavailable`. so operator will create it from scratch on next reconcile
+  - Or, delete manually associated PDB object, and operator will create it from scratch on next reconcile

--- a/roles/mappingservice/defaults/main.yml
+++ b/roles/mappingservice/defaults/main.yml
@@ -1,7 +1,14 @@
 ---
 
 ## Deployment
-replicas: 1
+pdb_state: "present"
+pdb_max_unavailable: 1
+hpa_state: "present"
+hpa_min_replicas: 2
+hpa_max_replicas: 4
+hpa_resource_name: "cpu"
+hpa_resource_utilization: 90
+replicas: 2
 image_name: "quay.io/3scale/apicast-cloud-hosted"
 apicast_log_level: warn
 liveness_probe_initial_delay_seconds: 5

--- a/roles/mappingservice/tasks/main.yml
+++ b/roles/mappingservice/tasks/main.yml
@@ -4,6 +4,26 @@
   k8s:
     definition: "{{ lookup('template', 'mappingservice-system-master-access-token-secretdefinition.yaml') }}"
 
+- name: Convert pdb.enabled boolean var into ansible pdb_state state var for MappingService {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    pdb_state: "absent"
+  when: pdb.enabled is defined and pdb.enabled|bool == false
+
+- name: Manage mapping-service PodDisruptionBudget for MappingService {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ pdb_state }}"
+    definition: "{{ lookup('template', 'mappingservice-pdb.yaml') }}"
+
+- name: Convert hpa.enabled boolean var into ansible hpa_state state var for MappingService {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    hpa_state: "absent"
+  when: hpa.enabled is defined and hpa.enabled|bool == false
+
+- name: Manage mapping-service HoritzontalPodAutoscaler for MappingService {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ hpa_state }}"
+    definition: "{{ lookup('template', 'mappingservice-hpa.yaml') }}"
+
 - name: Manage mapping-service Deployment for MappingService {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     definition: "{{ lookup('template', 'mappingservice-deployment.yaml') }}"

--- a/roles/mappingservice/templates/mappingservice-deployment.yaml
+++ b/roles/mappingservice/templates/mappingservice-deployment.yaml
@@ -7,7 +7,9 @@ metadata:
     app: mapping-service
     part-of: 3scale-saas
 spec:
+{% if hpa.enabled is defined and hpa.enabled == false %}
   replicas: {{ replicas }}
+{% endif %}
   selector:
     matchLabels:
       deployment: mapping-service

--- a/roles/mappingservice/templates/mappingservice-deployment.yaml
+++ b/roles/mappingservice/templates/mappingservice-deployment.yaml
@@ -93,3 +93,18 @@ spec:
             periodSeconds: {{ readiness_probe.period_seconds | default(readiness_probe_period_seconds) }}
             successThreshold: {{ readiness_probe.success_threshold | default(readiness_probe_success_threshold) }}
             failureThreshold: {{ readiness_probe.failure_threshold | default(readiness_probe_failure_threshold) }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  deployment: mapping-service
+          - weight: 99
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  deployment: mapping-service

--- a/roles/mappingservice/templates/mappingservice-hpa.yaml
+++ b/roles/mappingservice/templates/mappingservice-hpa.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: mapping-service
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: mapping-service
+    part-of: 3scale-saas
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mapping-service
+  minReplicas: {{ hpa.min_replicas | default(hpa_min_replicas) }}
+  maxReplicas: {{ hpa.max_replicas | default(hpa_max_replicas) }}
+  metrics:
+  - type: Resource
+    resource:
+      name: "{{ hpa.resource_name | default(hpa_resource_name) }}"
+      target:
+        type: Utilization
+        averageUtilization: {{ hpa.resource_utilization | default(hpa_resource_utilization) }}

--- a/roles/mappingservice/templates/mappingservice-pdb.yaml
+++ b/roles/mappingservice/templates/mappingservice-pdb.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: mapping-service
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: mapping-service
+    part-of: 3scale-saas
+spec:
+{% if pdb.min_available is not defined %}
+  maxUnavailable: {{ pdb.max_unavailable | default(pdb_max_unavailable) }}
+{% endif %}
+{% if pdb.min_available is defined %}
+  minAvailable: {{ pdb.min_available }}
+{% endif %}
+  selector:
+    matchLabels:
+      deployment: mapping-service


### PR DESCRIPTION
Solves part of https://github.com/3scale/saas-operator/issues/33:
- Add PodDisruptionBudget to mapping-service deployment
- Add HorizontalPodAutoscaler to mapping-service deployment
- Add podAntiaffinity to mapping-service deployment
- Update MappingService CRD with new supported pdb/hpa fields
- Update MappingService documentation with new supported pdb/hpa fields