### PR TITLE
Feature/Add HA EchoApi controller

### DIFF
--- a/deploy/crds/saas.3scale.net_echoapis_crd.yaml
+++ b/deploy/crds/saas.3scale.net_echoapis_crd.yaml
@@ -48,9 +48,44 @@ spec:
                 pullSecretName:
                   type: string
                   description: Quay pull secret for private repository
+            pdb:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: Enable (true) or disable (false) PodDisruptionBudget
+                maxUnavailable:
+                  type: string
+                  pattern: "^[0-9]+%?$"
+                  description: Maximum number of unavailable pods (number or percentage of pods)
+                minAvailable:
+                  type: string
+                  pattern: "^[0-9]+%?$"
+                  description: Minimum number of available pods (number or percentage of pods), overrides maxUnavailable
+            hpa:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: Enable (true) or disable (false) HoritzontalPodAutoscaler
+                minReplicas:
+                  type: integer
+                  description: Minimum number of replicas
+                maxReplicas:
+                  type: integer
+                  description: Maximum number of replicas
+                resourceName:
+                  type: string
+                  description: Resource used for autoscale (cpu/memory)
+                  enum:
+                  - cpu
+                  - memory
+                resourceUtilization:
+                  type: integer
+                  description: Percentage usage of the resource used for autoscale
             replicas:
               type: integer
-              description: Number of replicas
+              description: Number of replicas (ignored if hpa is enabled)
             resources:
               type: object
               properties:

--- a/docs/echoapi-crd-reference.md
+++ b/docs/echoapi-crd-reference.md
@@ -33,7 +33,15 @@ spec:
     name: quay.io/3scale/echoapi
     tag: v1.0.1
     pullSecretName: quay-pull-secret
-  replicas: 2
+  pdb:
+    enabled: true
+    maxUnavailable: "1"
+  hpa:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    resourceName: cpu
+    resourceUtilization: 90
   livenessProbe:
     initialDelaySeconds: 25
     timeoutSeconds: 2
@@ -71,7 +79,15 @@ spec:
 | `image.name` | `string` | No | `quay.io/3scale/echoapi` | Image name (docker repository) |
 | `image.tag` | `string` | No | `latest` | Image tag |
 | `image.pullSecretName` | `string` | No | - | Quay pull secret for private repository |
-| `replicas` | `int` | No | `2` | Number of replicas |
+| `pdb.enabled` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) PodDisruptionBudget |
+| `pdb.maxUnavailable` | `string` | No | `1` | Maximum number of unavailable pods (number or percentage of pods) ** |
+| `pdb.minAvailable` | `string` | No | - | Minimum number of available pods (number or percentage of pods), overrides maxUnavailable ** |
+| `hpa.enabled` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) HoritzontalPodAutoscaler |
+| `hpa.minReplicas` | `int` | No | `2` | Minimum number of replicas |
+| `hpa.maxReplicas` | `int` | No | `4` | Maximum number of replicas |
+| `hpa.resourceName` | `string` | No | `cpu` | Resource used for autoscale (cpu/memory) |
+| `hpa.resourceUtilization` | `int` | No | `90` | Percentage usage of the resource used for autoscale |
+| `replicas` | `int` | No | `2` | Number of replicas (ignored if hpa is enabled) |
 | `resources.requests.cpu` | `string` | No | `50m` | Override CPU requests |
 | `resources.requests.memory` | `string` | No | `40Mi` | Override Memory requests |
 | `resources.limits.cpu` | `string` | No | `150m` | Override CPU limits |
@@ -91,3 +107,7 @@ spec:
 | `marin3r.annotations.{}` | `map` | No | - | Map of marin3r annotations |
 | `loadBalancer.proxyProtocol` | `boolean` | No | `true` | Enable (`true`) or disable (`false`) proxy protocol with aws-nlb-helper-operator |
 | `loadBalancer.crossZoneLoadBalancingEnabled` | `bool` | No | `true` | Enable (`true`) or disable (`false`) cross zone load balancing |
+
+** If you are already using `pdb.maxUnavailable` and want to use `pdb.minAvailable` (or the other way around), due to ansible operator limitation of doing patch operation (if objects already exist), operator will receive an error when managing PDB object because although the spec of the PDB resource it creates is correct, operator will try to patch an existing object which already has the other variable, and these two variables `pdb.maxUnavailable`/`pdb.minAvailable` are mutually exclusive and cannot coexists on the same PDB. To solve that situation:
+  - Configure `pdb.enabled=false` (so operator will delete associated PDB, and then re-enable it with `pdb.enabled=true` setting desired PDB field `pdb.minAvailable` or `pdb.maxUnavailable`. so operator will create it from scratch on next reconcile
+  - Or, delete manually associated PDB object, and operator will create it from scratch on next reconcile

--- a/roles/echoapi/defaults/main.yml
+++ b/roles/echoapi/defaults/main.yml
@@ -1,6 +1,13 @@
 ---
 
 ## Deployment
+pdb_state: "present"
+pdb_max_unavailable: 1
+hpa_state: "present"
+hpa_min_replicas: 2
+hpa_max_replicas: 4
+hpa_resource_name: "cpu"
+hpa_resource_utilization: 90
 replicas: 2
 image_name: "quay.io/3scale/echoapi"
 image_tag: "latest"

--- a/roles/echoapi/tasks/main.yml
+++ b/roles/echoapi/tasks/main.yml
@@ -1,5 +1,25 @@
 ---
 
+- name: Convert pdb.enabled boolean var into ansible pdb_state state var for EchoAPI {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    pdb_state: "absent"
+  when: pdb.enabled is defined and pdb.enabled|bool == false
+
+- name: Manage echo-api PodDisruptionBudget for EchoAPI {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ pdb_state }}"
+    definition: "{{ lookup('template', 'echo-api-pdb.yaml') }}"
+
+- name: Convert hpa.enabled boolean var into ansible hpa_state state var for EchoAPI {{ meta.name }} on Namespace {{ meta.namespace }}
+  set_fact:
+    hpa_state: "absent"
+  when: hpa.enabled is defined and hpa.enabled|bool == false
+
+- name: Manage echo-api HoritzontalPodAutoscaler for EchoAPI {{ meta.name }} on Namespace {{ meta.namespace }}
+  k8s:
+    state: "{{ hpa_state }}"
+    definition: "{{ lookup('template', 'echo-api-hpa.yaml') }}"
+
 - name: Manage echo-api Deployment for EchoAPI {{ meta.name }} on Namespace {{ meta.namespace }}
   k8s:
     definition: "{{ lookup('template', 'echo-api-deployment.yaml') }}"

--- a/roles/echoapi/templates/echo-api-deployment.yaml
+++ b/roles/echoapi/templates/echo-api-deployment.yaml
@@ -70,4 +70,18 @@ spec:
             periodSeconds: {{ readiness_probe.period_seconds | default(readiness_probe_period_seconds) }}
             successThreshold: {{ readiness_probe.success_threshold | default(readiness_probe_success_threshold) }}
             failureThreshold: {{ readiness_probe.failure_threshold | default(readiness_probe_failure_threshold) }}
-
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  deployment: echo-api
+          - weight: 99
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchLabels:
+                  deployment: echo-api

--- a/roles/echoapi/templates/echo-api-deployment.yaml
+++ b/roles/echoapi/templates/echo-api-deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     threescale_component: echo-api
     threescale_component_element: echo-api
 spec:
+{% if hpa.enabled is defined and hpa.enabled == false %}
   replicas: {{ replicas }}
+{% endif %}
   selector:
     matchLabels:
       deployment: echo-api

--- a/roles/echoapi/templates/echo-api-hpa.yaml
+++ b/roles/echoapi/templates/echo-api-hpa.yaml
@@ -1,0 +1,23 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: echo-api
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: echo-api
+    threescale_component: echo-api
+    threescale_component_element: echo-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: echo-api
+  minReplicas: {{ hpa.min_replicas | default(hpa_min_replicas) }}
+  maxReplicas: {{ hpa.max_replicas | default(hpa_max_replicas) }}
+  metrics:
+  - type: Resource
+    resource:
+      name: "{{ hpa.resource_name | default(hpa_resource_name) }}"
+      target:
+        type: Utilization
+        averageUtilization: {{ hpa.resource_utilization | default(hpa_resource_utilization) }}

--- a/roles/echoapi/templates/echo-api-pdb.yaml
+++ b/roles/echoapi/templates/echo-api-pdb.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: echo-api
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: echo-api
+    threescale_component: echo-api
+    threescale_component_element: echo-api
+spec:
+{% if pdb.min_available is not defined %}
+  maxUnavailable: {{ pdb.max_unavailable | default(pdb_max_unavailable) }}
+{% endif %}
+{% if pdb.min_available is defined %}
+  minAvailable: {{ pdb.min_available }}
+{% endif %}
+  selector:
+    matchLabels:
+      deployment: echo-api


### PR DESCRIPTION
Solves part of https://github.com/3scale/saas-operator/issues/33:
- Add PodDisruptionBudget to echo-api deployment
- Add HorizontalPodAutoscaler to echo-api deployment
- Add podAntiaffinity to echo-api deployment
- Update EchoAPI CRD with new supported pdb/hpa fields
- Update EchoAPI documentation with new supported pdb/hpa fields