### PR TITLE
fix: remove duplicated block

### DIFF
--- a/roles/system/templates/statefulsets/system-sphinx.yaml
+++ b/roles/system/templates/statefulsets/system-sphinx.yaml
@@ -72,15 +72,7 @@ spec:
                 configMapKeyRef:
                   key: SPHINX_ADDRESS
                   name: system-sphinx
-              valueFrom:
-                configMapKeyRef:
-                  key: SPHINX_PORT
-                  name: system-sphinx
             - name: THINKING_SPHINX_PORT
-              valueFrom:
-                configMapKeyRef:
-                  key: SPHINX_PORT
-                  name: system-sphinx
               valueFrom:
                 configMapKeyRef:
                   key: SPHINX_PORT


### PR DESCRIPTION
This duplicated valueFrom code block was introduced by the MacBook Pro chaos engineering feature called random double key pressing.