### PR TITLE
Add management port to internal mapping-service Service

### DIFF
--- a/roles/mappingservice/templates/mappingservice-service.yaml
+++ b/roles/mappingservice/templates/mappingservice-service.yaml
@@ -12,5 +12,8 @@ spec:
     - name: mapping
       port: 80
       targetPort: mapping
+    - name: management
+      port: 8090
+      targetPort: management
   selector:
     deployment: mapping-service


### PR DESCRIPTION
We want to monitor mapping-service  status with blackbox exporter.

Mapping port (the main service port), cannot be used unless we harcode credentials on the probe yaml definition.

So at least by the moment, we are going to monitor the management port, the readiness endpoint `/status/ready`).

This PR publishes the management port in the internal ClusterIp `mapping-service` Service