### PR TITLE
feat/rollout-on-config-change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 0.9.0-alpha17
+VERSION ?= 0.9.0-alpha21
 # Default catalog image
 CATALOG_IMG ?= quay.io/3scaleops/go-saas-operator-catalog:latest
 # Default bundle image tag

--- a/api/v1alpha1/apicast_types.go
+++ b/api/v1alpha1/apicast_types.go
@@ -227,7 +227,7 @@ type ApicastList struct {
 	Items           []Apicast `json:"items"`
 }
 
-// Ensure AutoSSLList implements basereconciler.ExtendedObjectList
+// Ensure ApicastList implements basereconciler.ExtendedObjectList
 var _ basereconciler.ExtendedObjectList = &ApicastList{}
 
 // GetItem returns a client.Objectfrom a ApicastList

--- a/api/v1alpha1/apicast_types.go
+++ b/api/v1alpha1/apicast_types.go
@@ -17,12 +17,14 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/3scale/saas-operator/pkg/basereconciler"
 	"github.com/3scale/saas-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -223,6 +225,19 @@ type ApicastList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Apicast `json:"items"`
+}
+
+// Ensure AutoSSLList implements basereconciler.ExtendedObjectList
+var _ basereconciler.ExtendedObjectList = &ApicastList{}
+
+// GetItem returns a client.Objectfrom a ApicastList
+func (al *ApicastList) GetItem(idx int) client.Object {
+	return &al.Items[idx]
+}
+
+// CountItems returns the item count in ApicastList.Items
+func (al *ApicastList) CountItems() int {
+	return len(al.Items)
 }
 
 func init() {

--- a/api/v1alpha1/autossl_types.go
+++ b/api/v1alpha1/autossl_types.go
@@ -17,12 +17,14 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/3scale/saas-operator/pkg/basereconciler"
 	"github.com/3scale/saas-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -220,6 +222,19 @@ type AutoSSLList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []AutoSSL `json:"items"`
+}
+
+// Ensure AutoSSLList implements basereconciler.ExtendedObjectList
+var _ basereconciler.ExtendedObjectList = &AutoSSLList{}
+
+// GetItem returns a client.Objectfrom a AutoSSLList
+func (al *AutoSSLList) GetItem(idx int) client.Object {
+	return &al.Items[idx]
+}
+
+// CountItems returns the item count in AutoSSLList.Items
+func (al *AutoSSLList) CountItems() int {
+	return len(al.Items)
 }
 
 func init() {

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -26,6 +26,9 @@ import (
 const (
 	// Finalizer is the finalizer string for resoures in the saas group
 	Finalizer string = "saas.3scale.net"
+	// RolloutTriggerAnnotationKeyPrefix is a common prefix for all "rollout triggering"
+	// annotation keys
+	RolloutTriggerAnnotationKeyPrefix string = "saas.3scale.net/"
 )
 
 // ImageSpec defines the image for the component

--- a/api/v1alpha1/mappingservice_types.go
+++ b/api/v1alpha1/mappingservice_types.go
@@ -17,12 +17,14 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/3scale/saas-operator/pkg/basereconciler"
 	"github.com/3scale/saas-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -182,6 +184,19 @@ type MappingServiceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []MappingService `json:"items"`
+}
+
+// Ensure AutoSSLList implements basereconciler.ExtendedObjectList
+var _ basereconciler.ExtendedObjectList = &MappingServiceList{}
+
+// GetItem returns a client.Objectfrom a MappingServiceList
+func (msl *MappingServiceList) GetItem(idx int) client.Object {
+	return &msl.Items[idx]
+}
+
+// CountItems returns the item count in MappingServiceList.Items
+func (msl *MappingServiceList) CountItems() int {
+	return len(msl.Items)
 }
 
 func init() {

--- a/api/v1alpha1/mappingservice_types.go
+++ b/api/v1alpha1/mappingservice_types.go
@@ -186,7 +186,7 @@ type MappingServiceList struct {
 	Items           []MappingService `json:"items"`
 }
 
-// Ensure AutoSSLList implements basereconciler.ExtendedObjectList
+// Ensure MappingServiceList implements basereconciler.ExtendedObjectList
 var _ basereconciler.ExtendedObjectList = &MappingServiceList{}
 
 // GetItem returns a client.Objectfrom a MappingServiceList

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -133,7 +133,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.9.0-alpha17
+  name: saas-operator.v0.9.0-alpha21
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -441,7 +441,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:0.9.0-alpha17
+                image: quay.io/3scale/saas-operator:0.9.0-alpha21
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -512,6 +512,14 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - ""
@@ -678,4 +686,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.9.0-alpha17
+  version: 0.9.0-alpha21

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: 0.9.0-alpha17
+  newTag: 0.9.0-alpha21

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create

--- a/controllers/apicast_controller.go
+++ b/controllers/apicast_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -233,7 +234,7 @@ func (r *ApicastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 // SetupWithManager sets up the controller with the Manager.
 func (r *ApicastReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&saasv1alpha1.Apicast{}).
+		For(&saasv1alpha1.Apicast{}, builder.WithPredicates(util.ResourceGenerationOrFinalizerChangedPredicate{})).
 		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }

--- a/controllers/autossl_controller.go
+++ b/controllers/autossl_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -170,7 +171,7 @@ func (r *AutoSSLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 // SetupWithManager sets up the controller with the Manager.
 func (r *AutoSSLReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&saasv1alpha1.AutoSSL{}).
+		For(&saasv1alpha1.AutoSSL{}, builder.WithPredicates(util.ResourceGenerationOrFinalizerChangedPredicate{})).
 		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/davecgh/go-spew v1.1.1
 	github.com/go-logr/logr v0.3.0
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/onsi/ginkgo v1.14.1

--- a/pkg/generators/common_blocks/pod/util.go
+++ b/pkg/generators/common_blocks/pod/util.go
@@ -35,7 +35,7 @@ func TCPProbe(port intstr.IntOrString, cfg saasv1alpha1.ProbeSpec) *corev1.Probe
 	}
 	return &corev1.Probe{
 		Handler: corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
+			TCPSocket: &corev1.TCPSocketAction{
 				Port: port,
 			},
 		},

--- a/pkg/generators/mappingservice/deployment.go
+++ b/pkg/generators/mappingservice/deployment.go
@@ -3,6 +3,7 @@ package mappingservice
 import (
 	"fmt"
 
+	saasv1alpha1 "github.com/3scale/saas-operator/api/v1alpha1"
 	"github.com/3scale/saas-operator/pkg/basereconciler"
 	"github.com/3scale/saas-operator/pkg/generators/common_blocks/pod"
 	"github.com/3scale/saas-operator/pkg/generators/common_blocks/secrets"
@@ -16,7 +17,7 @@ import (
 
 // Deployment returns a basereconciler.GeneratorFunction function that will return a Deployment
 // resource when called
-func (gen *Generator) Deployment() basereconciler.GeneratorFunction {
+func (gen *Generator) Deployment(hash string) basereconciler.GeneratorFunction {
 
 	return func() client.Object {
 
@@ -43,6 +44,9 @@ func (gen *Generator) Deployment() basereconciler.GeneratorFunction {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: gen.LabelsWithSelector(),
+						Annotations: map[string]string{
+							saasv1alpha1.RolloutTriggerAnnotationKeyPrefix + "config.systemAdminToken.hash": hash,
+						},
 					},
 					Spec: corev1.PodSpec{
 						ImagePullSecrets: func() []corev1.LocalObjectReference {

--- a/pkg/generators/mappingservice/generator.go
+++ b/pkg/generators/mappingservice/generator.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	component             string = "mapping-service"
+	Component             string = "mapping-service"
 	masterTokenSecretName string = "mapping-service-system-master-access-token"
 )
 
@@ -28,11 +28,11 @@ type Generator struct {
 func NewGenerator(instance, namespace string, spec saasv1alpha1.MappingServiceSpec) Generator {
 	return Generator{
 		BaseOptions: generators.BaseOptions{
-			Component:    component,
+			Component:    Component,
 			InstanceName: instance,
 			Namespace:    namespace,
 			Labels: map[string]string{
-				"app":     component,
+				"app":     Component,
 				"part-of": "3scale-saas",
 			},
 		},

--- a/pkg/generators/mappingservice/generator.go
+++ b/pkg/generators/mappingservice/generator.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	Component             string = "mapping-service"
+	component             string = "mapping-service"
 	masterTokenSecretName string = "mapping-service-system-master-access-token"
 )
 
@@ -28,11 +28,11 @@ type Generator struct {
 func NewGenerator(instance, namespace string, spec saasv1alpha1.MappingServiceSpec) Generator {
 	return Generator{
 		BaseOptions: generators.BaseOptions{
-			Component:    Component,
+			Component:    component,
 			InstanceName: instance,
 			Namespace:    namespace,
 			Labels: map[string]string{
-				"app":     Component,
+				"app":     component,
 				"part-of": "3scale-saas",
 			},
 		},

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.9.0-alpha17"
+	version string = "v0.9.0-alpha21"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
This PR adds MappingService the ability to trigger a Deployment rollout upong a change of its `systemAdminToken` Secret. This is a mechanism required so Secrets (and ConfigMaps) are reloaded by the application when their values change. It has been implemented using an annotation with the hash of the Secret in the Pod spec.

Closes #58 

Note for reviewers: do not review until #57 has been merged.