### PR TITLE
Fix the secretdefinition generator

### DIFF
--- a/pkg/generators/common_blocks/secrets/secretdefinition.go
+++ b/pkg/generators/common_blocks/secrets/secretdefinition.go
@@ -53,9 +53,9 @@ func (sc *SecretConfiguration) GenerateSecretDefinitionFn(namespace string, labe
 
 func (sc *SecretConfiguration) keysMap(basePath string, serializedConfig []byte) (map[string]secretsmanagerv1alpha1.DataSource, error) {
 	dsm := map[string]secretsmanagerv1alpha1.DataSource{}
-	w := json.NewDecoder(bytes.NewReader([]byte(serializedConfig)))
 
 	for configOption, path := range sc.ConfigOptions {
+		w := json.NewDecoder(bytes.NewReader([]byte(serializedConfig)))
 		vsr := &saasv1alpha1.VaultSecretReference{}
 		relativePath := strings.TrimPrefix(path, basePath+"/")
 		pathElems := func() []interface{} {

--- a/pkg/generators/common_blocks/secrets/secretdefinition_test.go
+++ b/pkg/generators/common_blocks/secrets/secretdefinition_test.go
@@ -62,6 +62,42 @@ func TestSecretConfiguration_keysMap(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Builds SecretDefinition DataSources from serialized config, reversed order",
+			fields: fields{
+				SecretName: "secret-name",
+				ConfigOptions: map[string]string{
+					"SOME_CONFIG":  "/spec/config/someConfig",
+					"OTHER_CONFIG": "/spec/config/otherConfig",
+				},
+			},
+			args: args{
+				basePath: "/spec",
+				serializedConfig: []byte(heredoc.Doc(`
+					{
+						"config": {
+							"otherConfig": {
+								"fromVault": {
+									"path": "vault-path2",
+									"key": "vault-key2"
+								}
+							},
+							"someConfig": {
+								"fromVault": {
+									"path": "vault-path1",
+									"key": "vault-key1"
+								}
+							}
+						}
+					}
+				`)),
+			},
+			want: map[string]secretsmanagerv1alpha1.DataSource{
+				"SOME_CONFIG":  {Key: "vault-key1", Path: "vault-path1"},
+				"OTHER_CONFIG": {Key: "vault-key2", Path: "vault-path2"},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Fails if path is not found",
 			fields: fields{
 				SecretName: "secret-name",


### PR DESCRIPTION
The json decoder needs to be reinitialized for each SeekTo call because the decoder's cursor is moved to the position pointed by the arguments of SeekTo (a jsonpath) and subsequent calls to SeekTo will only find elements that are positioned after the cursor's position.