### PR TITLE
Fix custom resource deletion

### DIFF
--- a/controllers/apicast_controller.go
+++ b/controllers/apicast_controller.go
@@ -57,8 +57,8 @@ func (r *ApicastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	instance := &saasv1alpha1.Apicast{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
 	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, log)
-	if result.Requeue || err != nil {
-		return result, err
+	if result != nil || err != nil {
+		return *result, err
 	}
 
 	// Apply defaults for reconcile but do not store them in the API

--- a/controllers/autossl_controller.go
+++ b/controllers/autossl_controller.go
@@ -56,8 +56,8 @@ func (r *AutoSSLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	instance := &saasv1alpha1.AutoSSL{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
 	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, log)
-	if result.Requeue || err != nil {
-		return result, err
+	if result != nil || err != nil {
+		return *result, err
 	}
 
 	// Apply defaults for reconcile but do not store them in the API

--- a/controllers/backend_controller.go
+++ b/controllers/backend_controller.go
@@ -61,8 +61,8 @@ func (r *BackendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	instance := &saasv1alpha1.Backend{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
 	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, log)
-	if result.Requeue || err != nil {
-		return result, err
+	if result != nil || err != nil {
+		return *result, err
 	}
 
 	// Apply defaults for reconcile but do not store them in the API

--- a/controllers/corsproxy_controller.go
+++ b/controllers/corsproxy_controller.go
@@ -59,8 +59,8 @@ func (r *CORSProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	instance := &saasv1alpha1.CORSProxy{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
 	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, log)
-	if result.Requeue || err != nil {
-		return result, err
+	if result != nil || err != nil {
+		return *result, err
 	}
 
 	// Apply defaults for reconcile but do not store them in the API

--- a/controllers/mappingservice_controller.go
+++ b/controllers/mappingservice_controller.go
@@ -60,8 +60,8 @@ func (r *MappingServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	instance := &saasv1alpha1.MappingService{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
 	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, log)
-	if result.Requeue || err != nil {
-		return result, err
+	if result != nil || err != nil {
+		return *result, err
 	}
 
 	// Apply defaults for reconcile but do not store them in the API

--- a/pkg/basereconciler/test/test_controller.go
+++ b/pkg/basereconciler/test/test_controller.go
@@ -50,8 +50,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	instance := &v1alpha1.Test{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
 	result, err := r.GetInstance(ctx, key, instance, "finalizer.example.com", log)
-	if result.Requeue || err != nil {
-		return result, err
+	if result != nil || err != nil {
+		return *result, err
 	}
 
 	triggers, err := r.TriggersFromSecretDefs(ctx, secretDefinition(req.Namespace))


### PR DESCRIPTION
Reconcile was being retried after custom resources were marked for deletion, which is not correct and cause errors to apperar in the logs.