### PR TITLE
Update default backend-cron memory resources after switch docker base image to ubi8

### DIFF
--- a/api/v1alpha1/backend_types.go
+++ b/api/v1alpha1/backend_types.go
@@ -121,11 +121,11 @@ var (
 	backendDefaultCronResources          defaultResourceRequirementsSpec = defaultResourceRequirementsSpec{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),
-			corev1.ResourceMemory: resource.MustParse("40Mi"),
+			corev1.ResourceMemory: resource.MustParse("50Mi"),
 		},
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("150m"),
-			corev1.ResourceMemory: resource.MustParse("80Mi"),
+			corev1.ResourceMemory: resource.MustParse("150Mi"),
 		},
 	}
 )


### PR DESCRIPTION
On https://github.com/3scale/apisonator/pull/268 apisonator switched its source image from centos7 with ruby2.5 to ubi8 with ruby 2.7

We have seen on staging that when backend-cron pod is created, has a memory peak of 91MB (then decreases to 42MB), which exceeds default limit of 80MB, so OMM killer kills the pod before running OK.

This PR increases a bit default memory resources to match with current ubi8 usage, so OMM killer won't kill the pod upon startup.