### PR TITLE
feat/actions/release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,73 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.15"
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+
+      - uses: actions/cache@v2
+        with:
+          path: ./testbin
+          key: ${{ runner.os }}-testbin
+
+      - uses: actions/cache@v2
+        with:
+          path: ./bin
+          key: ${{ runner.os }}-bin
+
+      - name: Build image
+        run: make docker-build
+
+      - name: Export release name
+        run: |
+          echo "NEW_RELEASE=$(make get-new-release)" >> $GITHUB_ENV
+
+      - name: Login to quay.io/3scale
+        if: ${{ env.NEW_RELEASE != '' }}
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push new operator image
+        if: ${{ env.NEW_RELEASE != '' }}
+        run: make docker-push
+
+      - name: Login to quay.io/3scaleops
+        if: ${{ env.NEW_RELEASE != '' }}
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.CATALOG_REGISTRY_USER }}
+          password: ${{ secrets.CATALOG_REGISTRY_PASSWORD }}
+
+      - name: Publish new bundle image in saas-operator catalog
+        if: ${{ env.NEW_RELEASE != '' }}
+        run: make bundle-publish
+
+      - name: Create a new draft-release in github
+        if: ${{ env.NEW_RELEASE != '' }}
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ env.NEW_RELEASE }}"
+          title: "${{ env.NEW_RELEASE }}"
+          draft: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,6 @@
 name: test
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL:=/bin/bash
 # Current Operator version
-VERSION ?= 0.9.0-alpha.35
+VERSION ?= 0.9.0
 # Default catalog image
 CATALOG_IMG ?= quay.io/3scaleops/saas-operator-bundle:catalog
 # Default bundle image tag

--- a/Makefile
+++ b/Makefile
@@ -190,9 +190,9 @@ tmp:
 #### Release targets ####
 #########################
 
-prepare-release: bump-release generate fmt vet manifests bundle
+prepare-alpha-release: bump-release generate fmt vet manifests bundle
 
-prepare-stable-release: bump-release generate fmt vet manifests
+prepare-release: bump-release generate fmt vet manifests
 	$(MAKE) bundle CHANNELS=alpha,stable DEFAULT_CHANNEL=alpha
 
 bump-release:
@@ -201,7 +201,7 @@ bump-release:
 bundle-push: bundle bundle-build
 	docker push $(BUNDLE_IMG)
 
-bundle-publish: $(OPM) docker-build docker-push bundle-push
+bundle-publish: $(OPM) bundle-push
 	$(OPM) index add \
 		--build-tool docker \
 		--mode semver-skippatch \
@@ -209,6 +209,9 @@ bundle-publish: $(OPM) docker-build docker-push bundle-push
 		--from-index $(CATALOG_IMG) \
 		--tag $(CATALOG_IMG)
 	docker push $(CATALOG_IMG)
+
+get-new-release:
+	@hack/new-release.sh v$(VERSION)
 
 ############################################
 #### Targets to manually test with Kind ####

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -4,12 +4,14 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=saas-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha,stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.3.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -585,7 +585,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.9.0-alpha.35
+  name: saas-operator.v0.9.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -3038,7 +3038,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:0.9.0-alpha.35
+                image: quay.io/3scale/saas-operator:0.9.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -3425,4 +3425,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.9.0-alpha.35
+  version: 0.9.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,5 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: alpha,stable
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: 0.9.0-alpha.35
+  newTag: 0.9.0

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,8 @@ module github.com/3scale/saas-operator
 go 1.15
 
 require (
-	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/davecgh/go-spew v1.1.1
-	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 	github.com/go-logr/logr v0.3.0
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/onsi/ginkgo v1.14.1

--- a/hack/new-release.sh
+++ b/hack/new-release.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+REPO="3scale/saas-operator"
+
+# Skip if alpha release
+[[ ${1} == *"-alpha"* ]] && echo "" && exit 0
+
+# Skip if release already exists
+curl -o /dev/null --fail --silent "https://api.github.com/repos/${REPO}/releases/tags/${1}" && echo "" && exit 0
+
+echo ${1}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.9.0-alpha.35"
+	version string = "v0.9.0"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
Adds a release workflow and releases v0.9.0 of the operator. The release workflow works as follows:

* All the release process is controlled by the `VERSION` variable in the project's Makefile. This variable is used to generate the CSV of the operator, the tag of the bundle image and the number of the release that will get created in github
* Whenever a PR is merged to the `main` branch, the release workflow is triggered:
  1. Tests and builds the operator image
  2. Executes a small bash script `hack/new-release.sh` that checks if this is a new release by ensuring that it is not an alpha release and that a release matching that same version doesn't already exist in github. All following steps only execute if it is in fact a new release.
  3. Pushes the operator image
  4. Builds and pushes the bundle image and a new catalog image that includes this new bundle
  5. Creates a new draft release in github. This draft is automatically generated with the release version as the title and the list of new commits since the last release as the description.

I think it would be ideal if we always squash before merging PRs so the descriptions automatically generated when releases are created have better and more concise information.