### PR TITLE
fix/marin3r-annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL:=/bin/bash
 # Current Operator version
-VERSION ?= 0.9.3
+VERSION ?= 0.9.4
 # Default catalog image
 CATALOG_IMG ?= quay.io/3scaleops/saas-operator-bundle:catalog
 # Default bundle image tag

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -585,7 +585,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.9.3
+  name: saas-operator.v0.9.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -3038,7 +3038,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:0.9.3
+                image: quay.io/3scale/saas-operator:0.9.4
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -3425,4 +3425,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.9.3
+  version: 0.9.4

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: 0.9.3
+  newTag: 0.9.4

--- a/pkg/basereconciler/reconcile_resources.go
+++ b/pkg/basereconciler/reconcile_resources.go
@@ -276,7 +276,7 @@ func (r *Reconciler) DeploymentWithRolloutTriggers(deployment GeneratorFunction,
 
 	return func() client.Object {
 		dep := deployment().(*appsv1.Deployment)
-		if dep.GetAnnotations() == nil {
+		if dep.Spec.Template.ObjectMeta.Annotations == nil {
 			dep.Spec.Template.ObjectMeta.Annotations = map[string]string{}
 		}
 		for _, trigger := range triggers {
@@ -291,7 +291,7 @@ func (r *Reconciler) StatefulSetWithRolloutTriggers(statefulset GeneratorFunctio
 
 	return func() client.Object {
 		ss := statefulset().(*appsv1.StatefulSet)
-		if ss.GetAnnotations() == nil {
+		if ss.Spec.Template.ObjectMeta.Annotations == nil {
 			ss.Spec.Template.ObjectMeta.Annotations = map[string]string{}
 		}
 		for _, trigger := range triggers {

--- a/pkg/basereconciler/test/api/v1alpha1/example.com_tests.yaml
+++ b/pkg/basereconciler/test/api/v1alpha1/example.com_tests.yaml
@@ -36,6 +36,63 @@ spec:
           spec:
             description: TestSpec defines the desired state of Test
             properties:
+              marin3r:
+                description: Marin3rSidecarSpec defines the marin3r sidecar for the
+                  component
+                properties:
+                  extraPodAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Extra annotations to pass the Pod to further configure
+                      the sidecar container.
+                    type: object
+                  ports:
+                    description: The ports that the sidecar exposes
+                    items:
+                      description: SidecarPort defines port for the Marin3r sidecar
+                        container
+                      properties:
+                        name:
+                          description: Port name
+                          type: string
+                        port:
+                          description: Port value
+                          format: int32
+                          type: integer
+                      required:
+                      - name
+                      - port
+                      type: object
+                    type: array
+                  resources:
+                    description: Compute Resources required by this container.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - ports
+                type: object
               serviceAnnotations:
                 additionalProperties:
                   type: string

--- a/pkg/basereconciler/test/api/v1alpha1/test_types.go
+++ b/pkg/basereconciler/test/api/v1alpha1/test_types.go
@@ -20,6 +20,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	saasv1alpha1 "github.com/3scale/saas-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,6 +47,8 @@ var (
 type TestSpec struct {
 	// +optional
 	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
+	// +optional
+	Marin3r *saasv1alpha1.Marin3rSidecarSpec `json:"marin3r,omitempty"`
 }
 
 // TestStatus defines the observed state of Test

--- a/pkg/basereconciler/test/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/basereconciler/test/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	apiv1alpha1 "github.com/3scale/saas-operator/api/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -92,6 +93,11 @@ func (in *TestSpec) DeepCopyInto(out *TestSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Marin3r != nil {
+		in, out := &in.Marin3r, &out.Marin3r
+		*out = new(apiv1alpha1.Marin3rSidecarSpec)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.9.3"
+	version string = "v0.9.4"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
There was bug setting all Pod annotations to `map[string]string{}` and breaking the integration with marin3r. An integration tests has been added.

Create release 0.9.4