### PR TITLE
Fix NLB Service annotations by setting needed aws-load-balancer-type annotation

### DIFF
--- a/pkg/generators/common_blocks/service/util.go
+++ b/pkg/generators/common_blocks/service/util.go
@@ -34,6 +34,7 @@ func ELBServiceAnnotations(cfg saasv1alpha1.LoadBalancerSpec, hostnames []string
 // NLBServiceAnnotations returns annotations for services exposed through AWS Network LoadBalancers
 func NLBServiceAnnotations(cfg saasv1alpha1.NLBLoadBalancerSpec, hostnames []string) map[string]string {
 	annotations := map[string]string{
+		"service.beta.kubernetes.io/aws-load-balancer-type":                              "nlb",
 		"external-dns.alpha.kubernetes.io/hostname":                                      strings.Join(hostnames, ","),
 		"service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": fmt.Sprintf("%t", *cfg.CrossZoneLoadBalancingEnabled),
 	}


### PR DESCRIPTION
Right now the echo-api and backend-listener services are created with normal ELBs instead of NLBs, because the `NLBServiceAnnotations` function is not adding the proper annotation needed by aws-controller to create a NLB instead of default ELB.