### PR TITLE
Add missing SecretKeyBase envvar to Zync deployments

### DIFF
--- a/pkg/generators/zync/config/api_options.go
+++ b/pkg/generators/zync/config/api_options.go
@@ -29,6 +29,7 @@ func NewAPIOptions(spec saasv1alpha1.ZyncSpec) APIOptions {
 		RailsMaxThreads:  &pod.ClearTextValue{Value: fmt.Sprintf("%d", *spec.Config.Rails.MaxThreads)},
 
 		DatabaseURL:             &pod.SecretValue{Value: spec.Config.DatabaseDSN},
+		SecretKeyBase:           &pod.SecretValue{Value: spec.Config.SecretKeyBase},
 		ZyncAuthenticationToken: &pod.SecretValue{Value: spec.Config.ZyncAuthToken},
 	}
 

--- a/pkg/generators/zync/config/que_options.go
+++ b/pkg/generators/zync/config/que_options.go
@@ -25,6 +25,7 @@ func NewQueOptions(spec saasv1alpha1.ZyncSpec) QueOptions {
 		RailsLogToStdOut: &pod.ClearTextValue{Value: "true"},
 
 		DatabaseURL:             &pod.SecretValue{Value: spec.Config.DatabaseDSN},
+		SecretKeyBase:           &pod.SecretValue{Value: spec.Config.SecretKeyBase},
 		ZyncAuthenticationToken: &pod.SecretValue{Value: spec.Config.ZyncAuthToken},
 	}
 


### PR DESCRIPTION
The SecretKeyBase config item had no value assigned.